### PR TITLE
Fix card placement: show cards on board, use row clicks, auto-discard

### DIFF
--- a/e2e/card-placement.spec.ts
+++ b/e2e/card-placement.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from '@playwright/test';
+
+const PROJECT_ID = 'pineapple-poker-8f3';
+
+test.beforeEach(async () => {
+  await fetch(`http://localhost:8080/emulator/v1/projects/${PROJECT_ID}/databases/(default)/documents`, { method: 'DELETE' });
+  await fetch(`http://localhost:9099/emulator/v1/projects/${PROJECT_ID}/accounts`, { method: 'DELETE' });
+});
+
+/**
+ * Card placement UI tests: verifies that cards appear on the board when placed,
+ * rows are clickable (not individual slots), no undo/confirm buttons,
+ * and auto-discard/auto-submit work correctly.
+ */
+
+test('placed cards appear on board and auto-submit works', async ({ browser }) => {
+  const ctx1 = await browser.newContext();
+  const ctx2 = await browser.newContext();
+  const alice = await ctx1.newPage();
+  const bob = await ctx2.newPage();
+
+  // --- Both players join ---
+  await alice.goto('/');
+  await bob.goto('/');
+
+  await alice.getByTestId('name-input').fill('Alice');
+  await alice.getByTestId('join-button').click();
+  await alice.getByTestId('phase-label').waitFor({ timeout: 10_000 });
+
+  await bob.getByTestId('name-input').fill('Bob');
+  await bob.getByTestId('join-button').click();
+  await bob.getByTestId('phase-label').waitFor({ timeout: 10_000 });
+
+  // Wait for initial_deal phase
+  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
+
+  const board = alice.getByTestId('my-board');
+
+  // Wait for cards in hand
+  await alice.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+
+  // --- Verify: no confirm or undo buttons exist before placing ---
+  await expect(alice.getByTestId('confirm-button')).not.toBeVisible();
+  await expect(alice.getByTestId('undo-button')).not.toBeVisible();
+
+  // --- Verify: row click targets exist ---
+  await expect(board.getByTestId('row-top')).toBeVisible();
+  await expect(board.getByTestId('row-middle')).toBeVisible();
+  await expect(board.getByTestId('row-bottom')).toBeVisible();
+
+  // --- Verify: card appears on board after placing ---
+  // Count cards on board before placing (bottom row should have 0 white bg cards)
+  const bottomRow = board.getByTestId('row-bottom');
+
+  // Select first card and place on bottom row
+  await alice.getByTestId('hand-card-0').click();
+  await bottomRow.click();
+
+  // Card should now appear on the board — the bottom row should contain a card element (bg-white)
+  await expect(bottomRow.locator('.bg-white')).toHaveCount(1);
+
+  // Card should be removed from hand (hand-card count decreased)
+  // We started with 5 cards, now should have 4
+  await expect(alice.getByTestId('hand-card-3')).toBeVisible();
+  // 5th card (index 4) should no longer exist
+  await expect(alice.getByTestId('hand-card-4')).not.toBeVisible();
+
+  // --- Continue placing remaining cards to verify auto-submit ---
+  // Card 0 → bottom row
+  await alice.getByTestId('hand-card-0').click();
+  await board.getByTestId('row-bottom').click();
+
+  // Card 0 → middle row
+  await alice.getByTestId('hand-card-0').click();
+  await board.getByTestId('row-middle').click();
+
+  // Card 0 → middle row
+  await alice.getByTestId('hand-card-0').click();
+  await board.getByTestId('row-middle').click();
+
+  // Card 0 → top row (5th placement — should auto-submit)
+  await alice.getByTestId('hand-card-0').click();
+  await board.getByTestId('row-top').click();
+
+  // After auto-submit, should show "Waiting for other players..." or "Submitting..."
+  // (hand cards should be gone)
+  await expect(alice.getByTestId('hand-card-0')).not.toBeVisible({ timeout: 5_000 });
+
+  // --- No confirm button should have appeared at any point ---
+  await expect(alice.getByTestId('confirm-button')).not.toBeVisible();
+
+  // --- Bob places to advance game to street 2 ---
+  await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
+  await bob.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+
+  const bobBoard = bob.getByTestId('my-board');
+  for (let i = 0; i < 2; i++) {
+    await bob.getByTestId('hand-card-0').click();
+    await bobBoard.getByTestId('row-bottom').click();
+  }
+  for (let i = 0; i < 2; i++) {
+    await bob.getByTestId('hand-card-0').click();
+    await bobBoard.getByTestId('row-middle').click();
+  }
+  await bob.getByTestId('hand-card-0').click();
+  await bobBoard.getByTestId('row-top').click();
+
+  // --- Street 2: verify auto-discard (3 cards dealt, place 2, 3rd auto-discarded) ---
+  await expect(alice.getByTestId('phase-label')).toContainText('street_2', { timeout: 15_000 });
+  await alice.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+
+  // Should have 3 cards in hand
+  await expect(alice.getByTestId('hand-card-0')).toBeVisible();
+  await expect(alice.getByTestId('hand-card-1')).toBeVisible();
+  await expect(alice.getByTestId('hand-card-2')).toBeVisible();
+
+  // Place 2 cards — the 3rd should be auto-discarded and auto-submitted
+  await alice.getByTestId('hand-card-0').click();
+  await board.getByTestId('row-bottom').click();
+
+  await alice.getByTestId('hand-card-0').click();
+  await board.getByTestId('row-middle').click();
+
+  // After 2 placements, auto-submit should happen (no need to click discard or confirm)
+  // Hand should be cleared
+  await expect(alice.getByTestId('hand-card-0')).not.toBeVisible({ timeout: 5_000 });
+
+  // No confirm or undo buttons
+  await expect(alice.getByTestId('confirm-button')).not.toBeVisible();
+  await expect(alice.getByTestId('undo-button')).not.toBeVisible();
+
+  // Cleanup
+  await ctx1.close();
+  await ctx2.close();
+});

--- a/e2e/happy-path.spec.ts
+++ b/e2e/happy-path.spec.ts
@@ -12,45 +12,36 @@ test.beforeEach(async () => {
  * see round results, and the next round auto-starts.
  */
 
-/** Place cards for initial deal: 2 bottom, 2 middle, 1 top */
+/** Place cards for initial deal: 2 bottom, 2 middle, 1 top. Auto-submits. */
 async function placeInitialDeal(page: Page) {
   const board = page.getByTestId('my-board');
 
   // Wait for cards to appear in hand
   await page.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
 
-  // Card 0 → bottom slot 0
+  // Card 0 → bottom row
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-bottom-0').click();
+  await board.getByTestId('row-bottom').click();
 
-  // Card 0 (was card 1) → bottom slot 1
+  // Card 0 (was card 1) → bottom row
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-bottom-1').click();
+  await board.getByTestId('row-bottom').click();
 
-  // Card 0 (was card 2) → middle slot 0
+  // Card 0 (was card 2) → middle row
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-middle-0').click();
+  await board.getByTestId('row-middle').click();
 
-  // Card 0 (was card 3) → middle slot 1
+  // Card 0 (was card 3) → middle row
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-middle-1').click();
+  await board.getByTestId('row-middle').click();
 
-  // Card 0 (was card 4) → top slot 0
+  // Card 0 (was card 4) → top row — auto-submits after this
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-top-0').click();
-
-  // Click confirm
-  await page.getByTestId('confirm-button').click();
+  await board.getByTestId('row-top').click();
 }
 
 /**
- * Place cards for streets 2-5: place 2 cards, discard 1, confirm.
- * Placement strategy varies by street to fill the board correctly:
- *   Street 2: bottom(2), middle(2)  → +1 bottom, +1 middle
- *   Street 3: bottom(3), middle(3)  → +1 bottom, +1 middle
- *   Street 4: bottom(4), top(1)     → +1 bottom, +1 top
- *   Street 5: middle(4), top(2)     → +1 middle, +1 top
- * Final board: bottom=5, middle=5, top=3
+ * Place cards for streets 2-5: place 2 cards into rows, 3rd auto-discarded, auto-submits.
  */
 async function placeStreet(page: Page, street: number) {
   const board = page.getByTestId('my-board');
@@ -58,26 +49,20 @@ async function placeStreet(page: Page, street: number) {
   // Wait for 3 cards in hand
   await page.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
 
-  // Choose which rows to place into based on street number
   let row1: string, row2: string;
-  let slotIndex1: number, slotIndex2: number;
 
   switch (street) {
     case 2:
-      row1 = 'bottom'; slotIndex1 = 2;
-      row2 = 'middle'; slotIndex2 = 2;
+      row1 = 'bottom'; row2 = 'middle';
       break;
     case 3:
-      row1 = 'bottom'; slotIndex1 = 3;
-      row2 = 'middle'; slotIndex2 = 3;
+      row1 = 'bottom'; row2 = 'middle';
       break;
     case 4:
-      row1 = 'bottom'; slotIndex1 = 4;
-      row2 = 'top'; slotIndex2 = 1;
+      row1 = 'bottom'; row2 = 'top';
       break;
     case 5:
-      row1 = 'middle'; slotIndex1 = 4;
-      row2 = 'top'; slotIndex2 = 2;
+      row1 = 'middle'; row2 = 'top';
       break;
     default:
       throw new Error(`Unexpected street ${street}`);
@@ -85,17 +70,11 @@ async function placeStreet(page: Page, street: number) {
 
   // Place card 0 → row1
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId(`slot-${row1}-${slotIndex1}`).click();
+  await board.getByTestId(`row-${row1}`).click();
 
-  // Place card 0 (was card 1) → row2
+  // Place card 0 (was card 1) → row2 — auto-submits
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId(`slot-${row2}-${slotIndex2}`).click();
-
-  // Remaining card (index 0) becomes the discard — click it to mark
-  await page.getByTestId('hand-card-0').click();
-
-  // Confirm
-  await page.getByTestId('confirm-button').click();
+  await board.getByTestId(`row-${row2}`).click();
 }
 
 test('two players play a full round', async ({ browser }) => {

--- a/e2e/helpers/placement.ts
+++ b/e2e/helpers/placement.ts
@@ -1,43 +1,40 @@
 import type { Page } from '@playwright/test';
 
-/** Place cards for initial deal: 2 bottom, 2 middle, 1 top */
+/** Place cards for initial deal: 2 bottom, 2 middle, 1 top. Auto-submits. */
 export async function placeInitialDeal(page: Page) {
   const board = page.getByTestId('my-board');
 
   // Wait for cards to appear in hand
   await page.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
 
-  // Card 0 → bottom slot 0
+  // Card 0 → bottom row
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-bottom-0').click();
+  await board.getByTestId('row-bottom').click();
 
-  // Card 0 (was card 1) → bottom slot 1
+  // Card 0 (was card 1) → bottom row
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-bottom-1').click();
+  await board.getByTestId('row-bottom').click();
 
-  // Card 0 (was card 2) → middle slot 0
+  // Card 0 (was card 2) → middle row
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-middle-0').click();
+  await board.getByTestId('row-middle').click();
 
-  // Card 0 (was card 3) → middle slot 1
+  // Card 0 (was card 3) → middle row
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-middle-1').click();
+  await board.getByTestId('row-middle').click();
 
-  // Card 0 (was card 4) → top slot 0
+  // Card 0 (was card 4) → top row — auto-submits after this placement
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-top-0').click();
-
-  // Click confirm
-  await page.getByTestId('confirm-button').click();
+  await board.getByTestId('row-top').click();
 }
 
 /**
- * Place cards for streets 2-5: place 2 cards, discard 1, confirm.
+ * Place cards for streets 2-5: place 2 cards into rows, 3rd auto-discarded, auto-submits.
  * Placement strategy varies by street to fill the board correctly:
- *   Street 2: bottom(2), middle(2)  → +1 bottom, +1 middle
- *   Street 3: bottom(3), middle(3)  → +1 bottom, +1 middle
- *   Street 4: bottom(4), top(1)     → +1 bottom, +1 top
- *   Street 5: middle(4), top(2)     → +1 middle, +1 top
+ *   Street 2: bottom, middle  → +1 bottom, +1 middle
+ *   Street 3: bottom, middle  → +1 bottom, +1 middle
+ *   Street 4: bottom, top     → +1 bottom, +1 top
+ *   Street 5: middle, top     → +1 middle, +1 top
  * Final board: bottom=5, middle=5, top=3
  */
 export async function placeStreet(page: Page, street: number) {
@@ -48,24 +45,19 @@ export async function placeStreet(page: Page, street: number) {
 
   // Choose which rows to place into based on street number
   let row1: string, row2: string;
-  let slotIndex1: number, slotIndex2: number;
 
   switch (street) {
     case 2:
-      row1 = 'bottom'; slotIndex1 = 2;
-      row2 = 'middle'; slotIndex2 = 2;
+      row1 = 'bottom'; row2 = 'middle';
       break;
     case 3:
-      row1 = 'bottom'; slotIndex1 = 3;
-      row2 = 'middle'; slotIndex2 = 3;
+      row1 = 'bottom'; row2 = 'middle';
       break;
     case 4:
-      row1 = 'bottom'; slotIndex1 = 4;
-      row2 = 'top'; slotIndex2 = 1;
+      row1 = 'bottom'; row2 = 'top';
       break;
     case 5:
-      row1 = 'middle'; slotIndex1 = 4;
-      row2 = 'top'; slotIndex2 = 2;
+      row1 = 'middle'; row2 = 'top';
       break;
     default:
       throw new Error(`Unexpected street ${street}`);
@@ -73,15 +65,9 @@ export async function placeStreet(page: Page, street: number) {
 
   // Place card 0 → row1
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId(`slot-${row1}-${slotIndex1}`).click();
+  await board.getByTestId(`row-${row1}`).click();
 
-  // Place card 0 (was card 1) → row2
+  // Place card 0 (was card 1) → row2 — auto-submits (3rd card auto-discarded)
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId(`slot-${row2}-${slotIndex2}`).click();
-
-  // Remaining card (index 0) becomes the discard — click it to mark
-  await page.getByTestId('hand-card-0').click();
-
-  // Confirm
-  await page.getByTestId('confirm-button').click();
+  await board.getByTestId(`row-${row2}`).click();
 }

--- a/e2e/sit-out.spec.ts
+++ b/e2e/sit-out.spec.ts
@@ -12,70 +12,58 @@ test.beforeEach(async () => {
  * as sitting out. They see a "Rejoin" banner and must click it to play again.
  */
 
-/** Place cards for initial deal: 2 bottom, 2 middle, 1 top */
+/** Place cards for initial deal: 2 bottom, 2 middle, 1 top. Auto-submits. */
 async function placeInitialDeal(page: Page) {
   const board = page.getByTestId('my-board');
 
   await page.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
 
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-bottom-0').click();
+  await board.getByTestId('row-bottom').click();
 
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-bottom-1').click();
+  await board.getByTestId('row-bottom').click();
 
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-middle-0').click();
+  await board.getByTestId('row-middle').click();
 
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-middle-1').click();
+  await board.getByTestId('row-middle').click();
 
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId('slot-top-0').click();
-
-  await page.getByTestId('confirm-button').click();
+  await board.getByTestId('row-top').click();
 }
 
-/** Place cards for streets 2-5 */
+/** Place cards for streets 2-5. Auto-submits. */
 async function placeStreet(page: Page, street: number) {
   const board = page.getByTestId('my-board');
 
   await page.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
 
   let row1: string, row2: string;
-  let slotIndex1: number, slotIndex2: number;
 
   switch (street) {
     case 2:
-      row1 = 'bottom'; slotIndex1 = 2;
-      row2 = 'middle'; slotIndex2 = 2;
+      row1 = 'bottom'; row2 = 'middle';
       break;
     case 3:
-      row1 = 'bottom'; slotIndex1 = 3;
-      row2 = 'middle'; slotIndex2 = 3;
+      row1 = 'bottom'; row2 = 'middle';
       break;
     case 4:
-      row1 = 'bottom'; slotIndex1 = 4;
-      row2 = 'top'; slotIndex2 = 1;
+      row1 = 'bottom'; row2 = 'top';
       break;
     case 5:
-      row1 = 'middle'; slotIndex1 = 4;
-      row2 = 'top'; slotIndex2 = 2;
+      row1 = 'middle'; row2 = 'top';
       break;
     default:
       throw new Error(`Unexpected street ${street}`);
   }
 
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId(`slot-${row1}-${slotIndex1}`).click();
+  await board.getByTestId(`row-${row1}`).click();
 
   await page.getByTestId('hand-card-0').click();
-  await board.getByTestId(`slot-${row2}-${slotIndex2}`).click();
-
-  // Discard remaining card
-  await page.getByTestId('hand-card-0').click();
-
-  await page.getByTestId('confirm-button').click();
+  await board.getByTestId(`row-${row2}`).click();
 }
 
 test('timed-out player is sat out and can rejoin', async ({ browser }) => {

--- a/frontend/src/components/HandPanel.tsx
+++ b/frontend/src/components/HandPanel.tsx
@@ -1,15 +1,8 @@
 import { useCallback } from 'react';
-import { httpsCallable } from 'firebase/functions';
-import { functions } from '../firebase.ts';
-import type { Card, Row, GameState } from '@shared/core/types';
+import type { Card, GameState } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
 import { CardComponent } from './CardComponent.tsx';
-
-export interface Placement {
-  card: Card;
-  row: Row;
-  index: number;
-}
+import type { Placement } from './GamePage.tsx';
 
 function cardKey(c: Card): string {
   return `${c.rank}-${c.suit}`;
@@ -22,26 +15,18 @@ interface HandPanelProps {
   selectedIndex: number | null;
   onSelectCard: (index: number | null) => void;
   placements: Placement[];
-  onUndo: () => void;
-  discardIndex: number | null;
-  onDiscard: (index: number) => void;
+  submitting: boolean;
 }
 
 export function HandPanel({
   hand, gameState, uid, selectedIndex, onSelectCard,
-  placements, onUndo, discardIndex, onDiscard,
+  placements, submitting,
 }: HandPanelProps) {
   const isInitialDeal = gameState.phase === GamePhase.InitialDeal;
-  const isStreet = !isInitialDeal && gameState.phase !== GamePhase.Waiting &&
-    gameState.phase !== GamePhase.Scoring && gameState.phase !== GamePhase.Complete;
-  const needsDiscard = isStreet;
 
   const requiredPlacements = isInitialDeal ? 5 : 2;
   const placedCardKeys = new Set(placements.map((p) => cardKey(p.card)));
   const remainingHand = hand.filter((c) => !placedCardKeys.has(cardKey(c)));
-
-  const canSubmit = placements.length === requiredPlacements &&
-    (!needsDiscard || discardIndex !== null);
 
   const player = gameState.players[uid];
   const alreadyPlaced = player
@@ -52,34 +37,9 @@ export function HandPanel({
     : alreadyPlaced > 0 && hand.length === 0;
 
   const handleCardClick = useCallback((index: number) => {
-    if (needsDiscard && placements.length === requiredPlacements) {
-      onDiscard(index);
-      return;
-    }
+    if (submitting) return;
     onSelectCard(selectedIndex === index ? null : index);
-  }, [selectedIndex, needsDiscard, placements.length, requiredPlacements, onSelectCard, onDiscard]);
-
-  const handleSubmit = useCallback(async () => {
-    if (!canSubmit) return;
-    try {
-      const placeCards = httpsCallable(functions, 'placeCards');
-      const placementData = placements.map((p) => ({
-        card: p.card,
-        row: p.row,
-        index: p.index,
-      }));
-      const discard = needsDiscard && discardIndex !== null
-        ? remainingHand[discardIndex]
-        : null;
-
-      await placeCards({
-        placements: placementData,
-        discard,
-      });
-    } catch (err) {
-      console.error('Failed to place cards:', err);
-    }
-  }, [canSubmit, placements, needsDiscard, discardIndex, remainingHand]);
+  }, [selectedIndex, submitting, onSelectCard]);
 
   if (gameState.phase === GamePhase.Waiting) {
     return (
@@ -91,70 +51,46 @@ export function HandPanel({
 
   if (hand.length === 0 && !waitingForOthers) return null;
 
-  if (waitingForOthers) {
+  if (waitingForOthers || submitting) {
     return (
       <div className="bg-gray-900/80 border-t border-gray-700 p-4 text-center">
-        <span className="text-gray-400">Waiting for other players...</span>
+        <span className="text-gray-400">
+          {submitting ? 'Submitting...' : 'Waiting for other players...'}
+        </span>
       </div>
     );
   }
+
+  // Don't show cards that will be auto-discarded (only 1 remaining after all placements)
+  const allPlaced = placements.length >= requiredPlacements;
 
   return (
     <div className="bg-gray-900/80 border-t border-gray-700 p-4">
       <div className="max-w-2xl mx-auto">
         <div className="text-sm text-gray-400 mb-2 text-center">
           {isInitialDeal
-            ? 'Place all 5 cards on your board'
-            : `Place 2 cards, discard 1 (Street ${gameState.street})`}
-          {placements.length > 0 && (
+            ? 'Select a card, then click a row to place it'
+            : `Select a card, then click a row (Street ${gameState.street})`}
+          {placements.length > 0 && !allPlaced && (
             <span className="ml-2 text-gray-500">
               ({placements.length}/{requiredPlacements} placed)
             </span>
           )}
         </div>
 
-        <div className="flex justify-center gap-2 mb-3">
-          {remainingHand.map((card, i) => {
-            const isMarkedDiscard = discardIndex === i;
-            return (
+        {!allPlaced && (
+          <div className="flex justify-center gap-2 mb-3">
+            {remainingHand.map((card, i) => (
               <div key={cardKey(card)} className="relative" data-testid={`hand-card-${i}`}>
                 <CardComponent
                   card={card}
                   selected={selectedIndex === i}
                   onClick={() => handleCardClick(i)}
                 />
-                {isMarkedDiscard && (
-                  <div className="absolute inset-0 bg-red-600/40 rounded-lg flex items-center justify-center">
-                    <span className="text-xs font-bold text-white bg-red-600 px-1 rounded">
-                      DISCARD
-                    </span>
-                  </div>
-                )}
               </div>
-            );
-          })}
-        </div>
-
-        <div className="flex justify-center gap-3">
-          {placements.length > 0 && (
-            <button
-              data-testid="undo-button"
-              onClick={onUndo}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm transition-colors"
-            >
-              Undo
-            </button>
-          )}
-          {canSubmit && (
-            <button
-              data-testid="confirm-button"
-              onClick={handleSubmit}
-              className="px-6 py-2 bg-green-600 hover:bg-green-500 text-white rounded-lg text-sm font-semibold transition-colors"
-            >
-              Confirm
-            </button>
-          )}
-        </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/PlayerBoard.tsx
+++ b/frontend/src/components/PlayerBoard.tsx
@@ -3,19 +3,12 @@ import { CardComponent } from './CardComponent.tsx';
 
 interface SlotProps {
   card: Card | null;
-  row: Row;
-  index: number;
-  onSlotClick?: (row: Row, index: number) => void;
   small?: boolean;
 }
 
-function CardSlot({ card, row, index, onSlotClick, small }: SlotProps) {
+function CardSlot({ card, small }: SlotProps) {
   return (
-    <div
-      data-testid={`slot-${row}-${index}`}
-      onClick={onSlotClick && !card ? () => onSlotClick(row, index) : undefined}
-      className={!card && onSlotClick ? 'cursor-pointer' : ''}
-    >
+    <div>
       {card ? (
         <CardComponent card={card} small={small} />
       ) : (
@@ -24,7 +17,7 @@ function CardSlot({ card, row, index, onSlotClick, small }: SlotProps) {
             ${small ? 'w-10 h-14' : 'w-14 h-20'}
             rounded-lg border-2 border-dashed
             flex items-center justify-center
-            ${onSlotClick ? 'border-yellow-500/60 bg-yellow-900/20 hover:bg-yellow-900/40' : 'border-gray-600 bg-gray-800/30'}
+            border-gray-600 bg-gray-800/30
           `}
         />
       )}
@@ -43,14 +36,22 @@ interface PlayerBoardProps {
   playerName: string;
   fouled?: boolean;
   isCurrentPlayer?: boolean;
-  onSlotClick?: (row: Row, index: number) => void;
+  onRowClick?: (row: Row) => void;
+  hasCardSelected?: boolean;
   small?: boolean;
 }
 
-export function PlayerBoard({ board, playerName, fouled, isCurrentPlayer, onSlotClick, small }: PlayerBoardProps) {
+export function PlayerBoard({ board, playerName, fouled, isCurrentPlayer, onRowClick, hasCardSelected, small }: PlayerBoardProps) {
   const topSlots = padRow(board.top, 3);
   const middleSlots = padRow(board.middle, 5);
   const bottomSlots = padRow(board.bottom, 5);
+
+  const topHasSpace = board.top.length < 3;
+  const middleHasSpace = board.middle.length < 5;
+  const bottomHasSpace = board.bottom.length < 5;
+
+  const rowClickable = (hasSpace: boolean) =>
+    isCurrentPlayer && hasCardSelected && onRowClick && hasSpace;
 
   return (
     <div className={`
@@ -65,15 +66,19 @@ export function PlayerBoard({ board, playerName, fouled, isCurrentPlayer, onSlot
       </div>
 
       {/* Top row - 3 cards, centered */}
-      <div className="flex justify-center gap-1 mb-1">
+      <div
+        data-testid="row-top"
+        onClick={rowClickable(topHasSpace) ? () => onRowClick!('top' as Row) : undefined}
+        className={`
+          flex justify-center gap-1 mb-1 rounded px-1 py-0.5 transition-colors
+          ${rowClickable(topHasSpace) ? 'cursor-pointer bg-yellow-900/20 hover:bg-yellow-900/40 ring-1 ring-yellow-500/40' : ''}
+        `}
+      >
         <div className={small ? 'w-10' : 'w-14'} />
         {topSlots.map((card, i) => (
           <CardSlot
             key={`top-${i}`}
             card={card}
-            row={'top' as Row}
-            index={i}
-            onSlotClick={isCurrentPlayer ? onSlotClick : undefined}
             small={small}
           />
         ))}
@@ -81,28 +86,36 @@ export function PlayerBoard({ board, playerName, fouled, isCurrentPlayer, onSlot
       </div>
 
       {/* Middle row - 5 cards */}
-      <div className="flex justify-center gap-1 mb-1">
+      <div
+        data-testid="row-middle"
+        onClick={rowClickable(middleHasSpace) ? () => onRowClick!('middle' as Row) : undefined}
+        className={`
+          flex justify-center gap-1 mb-1 rounded px-1 py-0.5 transition-colors
+          ${rowClickable(middleHasSpace) ? 'cursor-pointer bg-yellow-900/20 hover:bg-yellow-900/40 ring-1 ring-yellow-500/40' : ''}
+        `}
+      >
         {middleSlots.map((card, i) => (
           <CardSlot
             key={`mid-${i}`}
             card={card}
-            row={'middle' as Row}
-            index={i}
-            onSlotClick={isCurrentPlayer ? onSlotClick : undefined}
             small={small}
           />
         ))}
       </div>
 
       {/* Bottom row - 5 cards */}
-      <div className="flex justify-center gap-1">
+      <div
+        data-testid="row-bottom"
+        onClick={rowClickable(bottomHasSpace) ? () => onRowClick!('bottom' as Row) : undefined}
+        className={`
+          flex justify-center gap-1 rounded px-1 py-0.5 transition-colors
+          ${rowClickable(bottomHasSpace) ? 'cursor-pointer bg-yellow-900/20 hover:bg-yellow-900/40 ring-1 ring-yellow-500/40' : ''}
+        `}
+      >
         {bottomSlots.map((card, i) => (
           <CardSlot
             key={`bot-${i}`}
             card={card}
-            row={'bottom' as Row}
-            index={i}
-            onSlotClick={isCurrentPlayer ? onSlotClick : undefined}
             small={small}
           />
         ))}

--- a/frontend/src/components/PlayerGrid.tsx
+++ b/frontend/src/components/PlayerGrid.tsx
@@ -1,13 +1,15 @@
-import type { GameState, Row } from '@shared/core/types';
+import type { GameState, Board, Row } from '@shared/core/types';
 import { PlayerBoard } from './PlayerBoard.tsx';
 
 interface PlayerGridProps {
   gameState: GameState;
   currentUid: string;
-  onSlotClick?: (row: Row, index: number) => void;
+  currentPlayerBoard?: Board;
+  onRowClick?: (row: Row) => void;
+  hasCardSelected?: boolean;
 }
 
-export function PlayerGrid({ gameState, currentUid, onSlotClick }: PlayerGridProps) {
+export function PlayerGrid({ gameState, currentUid, currentPlayerBoard, onRowClick, hasCardSelected }: PlayerGridProps) {
   const otherPlayers = gameState.playerOrder.filter((uid) => uid !== currentUid);
   const currentPlayer = gameState.players[currentUid];
 
@@ -36,11 +38,12 @@ export function PlayerGrid({ gameState, currentUid, onSlotClick }: PlayerGridPro
       {currentPlayer && (
         <div data-testid="my-board" className="flex justify-center">
           <PlayerBoard
-            board={currentPlayer.board}
+            board={currentPlayerBoard || currentPlayer.board}
             playerName={`${currentPlayer.displayName} (You)`}
             fouled={currentPlayer.fouled}
             isCurrentPlayer
-            onSlotClick={onSlotClick}
+            onRowClick={onRowClick}
+            hasCardSelected={hasCardSelected}
           />
         </div>
       )}


### PR DESCRIPTION
Three issues fixed:
- Cards now appear on the board immediately when placed (merged board
  overlays local placements onto Firestore state)
- Empty slots no longer look individually clickable; entire rows are
  the click target with visual highlight when a card is selected
- Placing 2 cards on streets 2-5 auto-discards the 3rd and auto-submits;
  no explicit discard step or confirm button needed. Placements are
  non-undoable. Initial deal also auto-submits after all 5 placed.

Updated all e2e tests for new row-click flow and added new
card-placement.spec.ts verifying the UI changes.

https://claude.ai/code/session_01U6MgdunbaZhDovPf9vMtGt