### PR TITLE
Add unit tests for shared game logic with vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "dealer"
       ],
       "devDependencies": {
-        "@playwright/test": "^1.58.2"
+        "@playwright/test": "^1.58.2",
+        "vitest": "^4.0.18"
       }
     },
     "dealer": {
@@ -2214,6 +2215,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.1.18.tgz",
@@ -2543,6 +2551,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2560,6 +2579,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3014,6 +3040,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3134,6 +3271,16 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-retry": {
@@ -3357,6 +3504,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3676,6 +3833,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -3947,6 +4111,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3974,6 +4148,16 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -5670,6 +5854,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -5788,6 +5983,13 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -6357,6 +6559,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6366,6 +6575,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -6374,6 +6590,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -6551,6 +6774,23 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6565,6 +6805,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -6853,6 +7103,84 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
@@ -6912,6 +7240,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,11 @@
 {
   "name": "pineapple-poker",
   "private": true,
-  "workspaces": ["frontend", "functions", "dealer"],
+  "workspaces": [
+    "frontend",
+    "functions",
+    "dealer"
+  ],
   "scripts": {
     "dev": "npm run dev -w frontend",
     "build": "npm run build -w frontend",
@@ -11,9 +15,11 @@
     "functions:watch": "npm run build:watch -w functions",
     "dev:up": "./scripts/dev-up.sh",
     "dev:down": "./scripts/dev-down.sh",
-    "test": "npx playwright test"
+    "test": "npx playwright test",
+    "test:unit": "vitest run --config shared/vitest.config.ts"
   },
   "devDependencies": {
-    "@playwright/test": "^1.58.2"
+    "@playwright/test": "^1.58.2",
+    "vitest": "^4.0.18"
   }
 }

--- a/shared/core/firestore-paths.test.ts
+++ b/shared/core/firestore-paths.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { GAME_DOC, handDoc, deckDoc } from './firestore-paths';
+
+describe('GAME_DOC', () => {
+  it('is the expected path', () => {
+    expect(GAME_DOC).toBe('games/current');
+  });
+});
+
+describe('handDoc', () => {
+  it('returns default path with current game', () => {
+    expect(handDoc('player1')).toBe('games/current/hands/player1');
+  });
+
+  it('uses custom gameId', () => {
+    expect(handDoc('player1', 'game123')).toBe('games/game123/hands/player1');
+  });
+});
+
+describe('deckDoc', () => {
+  it('returns default path with current game', () => {
+    expect(deckDoc('player1')).toBe('games/current/decks/player1');
+  });
+
+  it('uses custom gameId', () => {
+    expect(deckDoc('player1', 'game123')).toBe('games/game123/decks/player1');
+  });
+});

--- a/shared/game-logic/board-utils.test.ts
+++ b/shared/game-logic/board-utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { emptyBoard, phaseForStreet } from './board-utils';
+
+describe('emptyBoard', () => {
+  it('returns a board with three empty arrays', () => {
+    const board = emptyBoard();
+    expect(board.top).toEqual([]);
+    expect(board.middle).toEqual([]);
+    expect(board.bottom).toEqual([]);
+  });
+
+  it('returns a new object each time', () => {
+    const a = emptyBoard();
+    const b = emptyBoard();
+    expect(a).not.toBe(b);
+    expect(a.top).not.toBe(b.top);
+  });
+});
+
+describe('phaseForStreet', () => {
+  it('maps street 1 to initial_deal', () => {
+    expect(phaseForStreet(1)).toBe('initial_deal');
+  });
+
+  it('maps street 2 to street_2', () => {
+    expect(phaseForStreet(2)).toBe('street_2');
+  });
+
+  it('maps street 3 to street_3', () => {
+    expect(phaseForStreet(3)).toBe('street_3');
+  });
+
+  it('maps street 4 to street_4', () => {
+    expect(phaseForStreet(4)).toBe('street_4');
+  });
+
+  it('maps street 5 to street_5', () => {
+    expect(phaseForStreet(5)).toBe('street_5');
+  });
+
+  it('maps out-of-range streets to scoring', () => {
+    expect(phaseForStreet(0)).toBe('scoring');
+    expect(phaseForStreet(6)).toBe('scoring');
+    expect(phaseForStreet(100)).toBe('scoring');
+  });
+});

--- a/shared/game-logic/deck.test.ts
+++ b/shared/game-logic/deck.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { createDeck, shuffleDeck, dealCards, createShuffledDeck } from './deck';
+import { Suit, Rank } from '../core/types';
+import type { Card } from '../core/types';
+
+describe('createDeck', () => {
+  it('creates a 52-card deck', () => {
+    const deck = createDeck();
+    expect(deck).toHaveLength(52);
+  });
+
+  it('contains all 4 suits', () => {
+    const deck = createDeck();
+    const suits = new Set(deck.map((c) => c.suit));
+    expect(suits).toEqual(new Set([Suit.Clubs, Suit.Diamonds, Suit.Hearts, Suit.Spades]));
+  });
+
+  it('contains all 13 ranks', () => {
+    const deck = createDeck();
+    const ranks = new Set(deck.map((c) => c.rank));
+    expect(ranks.size).toBe(13);
+    expect(ranks).toContain(Rank.Two);
+    expect(ranks).toContain(Rank.Ace);
+  });
+
+  it('has no duplicate cards', () => {
+    const deck = createDeck();
+    const keys = deck.map((c) => `${c.suit}${c.rank}`);
+    expect(new Set(keys).size).toBe(52);
+  });
+
+  it('returns a new array each time', () => {
+    const a = createDeck();
+    const b = createDeck();
+    expect(a).not.toBe(b);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('shuffleDeck', () => {
+  it('returns the same array reference (in-place)', () => {
+    const deck = createDeck();
+    const result = shuffleDeck(deck);
+    expect(result).toBe(deck);
+  });
+
+  it('preserves all 52 cards', () => {
+    const deck = createDeck();
+    shuffleDeck(deck);
+    expect(deck).toHaveLength(52);
+    const keys = deck.map((c) => `${c.suit}${c.rank}`);
+    expect(new Set(keys).size).toBe(52);
+  });
+
+  it('changes card ordering (statistical)', () => {
+    // Shuffle many times and check that at least some orderings differ
+    const original = createDeck();
+    const originalKeys = original.map((c) => `${c.suit}${c.rank}`).join(',');
+
+    let differentCount = 0;
+    for (let i = 0; i < 5; i++) {
+      const deck = createDeck();
+      shuffleDeck(deck);
+      const keys = deck.map((c) => `${c.suit}${c.rank}`).join(',');
+      if (keys !== originalKeys) differentCount++;
+    }
+    // Extremely unlikely all 5 shuffles produce the same order
+    expect(differentCount).toBeGreaterThan(0);
+  });
+});
+
+describe('dealCards', () => {
+  it('deals the correct number of cards', () => {
+    const deck = createDeck();
+    const { dealt, remaining } = dealCards(deck, 5);
+    expect(dealt).toHaveLength(5);
+    expect(remaining).toHaveLength(47);
+  });
+
+  it('does not mutate the original deck', () => {
+    const deck = createDeck();
+    const originalLength = deck.length;
+    dealCards(deck, 5);
+    expect(deck).toHaveLength(originalLength);
+  });
+
+  it('deals from the top of the deck', () => {
+    const deck = createDeck();
+    const { dealt } = dealCards(deck, 3);
+    expect(dealt).toEqual(deck.slice(0, 3));
+  });
+
+  it('remaining is the rest of the deck', () => {
+    const deck = createDeck();
+    const { remaining } = dealCards(deck, 3);
+    expect(remaining).toEqual(deck.slice(3));
+  });
+
+  it('deals all cards when count equals deck size', () => {
+    const deck = createDeck();
+    const { dealt, remaining } = dealCards(deck, 52);
+    expect(dealt).toHaveLength(52);
+    expect(remaining).toHaveLength(0);
+  });
+
+  it('deals zero cards', () => {
+    const deck = createDeck();
+    const { dealt, remaining } = dealCards(deck, 0);
+    expect(dealt).toHaveLength(0);
+    expect(remaining).toHaveLength(52);
+  });
+
+  it('throws when trying to deal more cards than available', () => {
+    const deck = createDeck();
+    expect(() => dealCards(deck, 53)).toThrow('Cannot deal 53 cards from deck of 52');
+  });
+});
+
+describe('createShuffledDeck', () => {
+  it('returns a 52-card deck', () => {
+    const deck = createShuffledDeck();
+    expect(deck).toHaveLength(52);
+  });
+
+  it('contains all unique cards', () => {
+    const deck = createShuffledDeck();
+    const keys = deck.map((c) => `${c.suit}${c.rank}`);
+    expect(new Set(keys).size).toBe(52);
+  });
+});

--- a/shared/game-logic/hand-evaluation.test.ts
+++ b/shared/game-logic/hand-evaluation.test.ts
@@ -1,0 +1,506 @@
+import { describe, it, expect } from 'vitest';
+import {
+  evaluate5CardHand,
+  evaluate3CardHand,
+  compareHands,
+  compare5CardHands,
+  compare3CardHands,
+  compareRows,
+} from './hand-evaluation';
+import { HandRank, Rank, Suit, ThreeCardHandRank } from '../core/types';
+import type { Card } from '../core/types';
+
+// -- Helpers to build cards concisely --
+
+function card(rank: Rank, suit: Suit = Suit.Spades): Card {
+  return { rank, suit };
+}
+
+const c = Suit.Clubs;
+const d = Suit.Diamonds;
+const h = Suit.Hearts;
+const s = Suit.Spades;
+
+// ---- 5-card hand evaluation ----
+
+describe('evaluate5CardHand', () => {
+  it('throws if not exactly 5 cards', () => {
+    expect(() => evaluate5CardHand([])).toThrow('Expected 5 cards');
+    expect(() => evaluate5CardHand([card(Rank.Ace)])).toThrow('Expected 5 cards');
+  });
+
+  it('detects Royal Flush', () => {
+    const hand: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.King, suit: s },
+      { rank: Rank.Queen, suit: s },
+      { rank: Rank.Jack, suit: s },
+      { rank: Rank.Ten, suit: s },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.RoyalFlush);
+  });
+
+  it('detects Straight Flush', () => {
+    const hand: Card[] = [
+      { rank: Rank.Nine, suit: h },
+      { rank: Rank.Eight, suit: h },
+      { rank: Rank.Seven, suit: h },
+      { rank: Rank.Six, suit: h },
+      { rank: Rank.Five, suit: h },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.StraightFlush);
+    expect(result.kickers).toEqual([Rank.Nine]);
+  });
+
+  it('detects Wheel Straight Flush (A-2-3-4-5)', () => {
+    const hand: Card[] = [
+      { rank: Rank.Ace, suit: d },
+      { rank: Rank.Two, suit: d },
+      { rank: Rank.Three, suit: d },
+      { rank: Rank.Four, suit: d },
+      { rank: Rank.Five, suit: d },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.StraightFlush);
+    expect(result.kickers).toEqual([Rank.Five]); // 5-high
+  });
+
+  it('detects Four of a Kind', () => {
+    const hand: Card[] = [
+      { rank: Rank.King, suit: s },
+      { rank: Rank.King, suit: h },
+      { rank: Rank.King, suit: d },
+      { rank: Rank.King, suit: c },
+      { rank: Rank.Three, suit: s },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.FourOfAKind);
+    expect(result.kickers).toEqual([Rank.King, Rank.Three]);
+  });
+
+  it('detects Full House', () => {
+    const hand: Card[] = [
+      { rank: Rank.Ten, suit: s },
+      { rank: Rank.Ten, suit: h },
+      { rank: Rank.Ten, suit: d },
+      { rank: Rank.Four, suit: c },
+      { rank: Rank.Four, suit: s },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.FullHouse);
+    expect(result.kickers).toEqual([Rank.Ten, Rank.Four]);
+  });
+
+  it('detects Flush', () => {
+    const hand: Card[] = [
+      { rank: Rank.Ace, suit: c },
+      { rank: Rank.Jack, suit: c },
+      { rank: Rank.Eight, suit: c },
+      { rank: Rank.Five, suit: c },
+      { rank: Rank.Three, suit: c },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.Flush);
+    expect(result.kickers).toEqual([Rank.Ace, Rank.Jack, Rank.Eight, Rank.Five, Rank.Three]);
+  });
+
+  it('detects Straight', () => {
+    const hand: Card[] = [
+      { rank: Rank.Eight, suit: s },
+      { rank: Rank.Seven, suit: h },
+      { rank: Rank.Six, suit: d },
+      { rank: Rank.Five, suit: c },
+      { rank: Rank.Four, suit: s },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.Straight);
+    expect(result.kickers).toEqual([Rank.Eight]);
+  });
+
+  it('detects Wheel Straight (A-2-3-4-5, not flush)', () => {
+    const hand: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.Two, suit: h },
+      { rank: Rank.Three, suit: d },
+      { rank: Rank.Four, suit: c },
+      { rank: Rank.Five, suit: s },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.Straight);
+    expect(result.kickers).toEqual([Rank.Five]); // 5-high
+  });
+
+  it('detects Broadway Straight (A-K-Q-J-T, not flush)', () => {
+    const hand: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.King, suit: h },
+      { rank: Rank.Queen, suit: d },
+      { rank: Rank.Jack, suit: c },
+      { rank: Rank.Ten, suit: s },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.Straight);
+    expect(result.kickers).toEqual([Rank.Ace]);
+  });
+
+  it('detects Three of a Kind', () => {
+    const hand: Card[] = [
+      { rank: Rank.Seven, suit: s },
+      { rank: Rank.Seven, suit: h },
+      { rank: Rank.Seven, suit: d },
+      { rank: Rank.King, suit: c },
+      { rank: Rank.Two, suit: s },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.ThreeOfAKind);
+    expect(result.kickers).toEqual([Rank.Seven, Rank.King, Rank.Two]);
+  });
+
+  it('detects Two Pair', () => {
+    const hand: Card[] = [
+      { rank: Rank.Jack, suit: s },
+      { rank: Rank.Jack, suit: h },
+      { rank: Rank.Four, suit: d },
+      { rank: Rank.Four, suit: c },
+      { rank: Rank.Ace, suit: s },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.TwoPair);
+    expect(result.kickers).toEqual([Rank.Jack, Rank.Four, Rank.Ace]);
+  });
+
+  it('detects One Pair', () => {
+    const hand: Card[] = [
+      { rank: Rank.Nine, suit: s },
+      { rank: Rank.Nine, suit: h },
+      { rank: Rank.Ace, suit: d },
+      { rank: Rank.King, suit: c },
+      { rank: Rank.Two, suit: s },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.Pair);
+    expect(result.kickers).toEqual([Rank.Nine, Rank.Ace, Rank.King, Rank.Two]);
+  });
+
+  it('detects High Card', () => {
+    const hand: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.Ten, suit: h },
+      { rank: Rank.Eight, suit: d },
+      { rank: Rank.Five, suit: c },
+      { rank: Rank.Three, suit: h },
+    ];
+    const result = evaluate5CardHand(hand);
+    expect(result.handRank).toBe(HandRank.HighCard);
+    expect(result.kickers).toEqual([Rank.Ace, Rank.Ten, Rank.Eight, Rank.Five, Rank.Three]);
+  });
+});
+
+// ---- 3-card hand evaluation ----
+
+describe('evaluate3CardHand', () => {
+  it('throws if not exactly 3 cards', () => {
+    expect(() => evaluate3CardHand([])).toThrow('Expected 3 cards');
+    expect(() => evaluate3CardHand([card(Rank.Ace), card(Rank.King)])).toThrow('Expected 3 cards');
+  });
+
+  it('detects Three of a Kind', () => {
+    const hand: Card[] = [
+      { rank: Rank.Queen, suit: s },
+      { rank: Rank.Queen, suit: h },
+      { rank: Rank.Queen, suit: d },
+    ];
+    const result = evaluate3CardHand(hand);
+    expect(result.handRank).toBe(ThreeCardHandRank.ThreeOfAKind);
+    expect(result.kickers).toEqual([Rank.Queen]);
+  });
+
+  it('detects Pair', () => {
+    const hand: Card[] = [
+      { rank: Rank.Five, suit: s },
+      { rank: Rank.Five, suit: h },
+      { rank: Rank.King, suit: d },
+    ];
+    const result = evaluate3CardHand(hand);
+    expect(result.handRank).toBe(ThreeCardHandRank.Pair);
+    expect(result.kickers).toEqual([Rank.Five, Rank.King]);
+  });
+
+  it('detects High Card', () => {
+    const hand: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.Seven, suit: h },
+      { rank: Rank.Two, suit: d },
+    ];
+    const result = evaluate3CardHand(hand);
+    expect(result.handRank).toBe(ThreeCardHandRank.HighCard);
+    expect(result.kickers).toEqual([Rank.Ace, Rank.Seven, Rank.Two]);
+  });
+});
+
+// ---- Comparison functions ----
+
+describe('compareHands', () => {
+  it('higher handRank wins', () => {
+    const flush = { handRank: HandRank.Flush, kickers: [14, 10, 8, 5, 3] };
+    const pair = { handRank: HandRank.Pair, kickers: [14, 13, 10, 5] };
+    expect(compareHands(flush, pair)).toBe(1);
+    expect(compareHands(pair, flush)).toBe(-1);
+  });
+
+  it('same handRank compares kickers', () => {
+    const pairAces = { handRank: HandRank.Pair, kickers: [14, 13, 10, 5] };
+    const pairKings = { handRank: HandRank.Pair, kickers: [13, 14, 10, 5] };
+    expect(compareHands(pairAces, pairKings)).toBe(1);
+    expect(compareHands(pairKings, pairAces)).toBe(-1);
+  });
+
+  it('identical hands are tied', () => {
+    const a = { handRank: HandRank.TwoPair, kickers: [10, 5, 3] };
+    const b = { handRank: HandRank.TwoPair, kickers: [10, 5, 3] };
+    expect(compareHands(a, b)).toBe(0);
+  });
+
+  it('compares deeper kickers for tiebreaking', () => {
+    const a = { handRank: HandRank.HighCard, kickers: [14, 13, 10, 8, 5] };
+    const b = { handRank: HandRank.HighCard, kickers: [14, 13, 10, 8, 4] };
+    expect(compareHands(a, b)).toBe(1);
+    expect(compareHands(b, a)).toBe(-1);
+  });
+});
+
+describe('compare5CardHands', () => {
+  it('flush beats straight', () => {
+    const flush: Card[] = [
+      { rank: Rank.Ace, suit: c },
+      { rank: Rank.Jack, suit: c },
+      { rank: Rank.Eight, suit: c },
+      { rank: Rank.Five, suit: c },
+      { rank: Rank.Three, suit: c },
+    ];
+    const straight: Card[] = [
+      { rank: Rank.Eight, suit: s },
+      { rank: Rank.Seven, suit: h },
+      { rank: Rank.Six, suit: d },
+      { rank: Rank.Five, suit: c },
+      { rank: Rank.Four, suit: s },
+    ];
+    expect(compare5CardHands(flush, straight)).toBe(1);
+    expect(compare5CardHands(straight, flush)).toBe(-1);
+  });
+
+  it('higher pair beats lower pair', () => {
+    const pairAces: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.Ace, suit: h },
+      { rank: Rank.Five, suit: d },
+      { rank: Rank.Three, suit: c },
+      { rank: Rank.Two, suit: s },
+    ];
+    const pairKings: Card[] = [
+      { rank: Rank.King, suit: s },
+      { rank: Rank.King, suit: h },
+      { rank: Rank.Queen, suit: d },
+      { rank: Rank.Jack, suit: c },
+      { rank: Rank.Ten, suit: s },
+    ];
+    expect(compare5CardHands(pairAces, pairKings)).toBe(1);
+  });
+
+  it('identical hands tie', () => {
+    const a: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.King, suit: s },
+      { rank: Rank.Queen, suit: s },
+      { rank: Rank.Jack, suit: s },
+      { rank: Rank.Nine, suit: s },
+    ];
+    const b: Card[] = [
+      { rank: Rank.Ace, suit: h },
+      { rank: Rank.King, suit: h },
+      { rank: Rank.Queen, suit: h },
+      { rank: Rank.Jack, suit: h },
+      { rank: Rank.Nine, suit: h },
+    ];
+    // Both are flushes with same kickers
+    expect(compare5CardHands(a, b)).toBe(0);
+  });
+});
+
+describe('compare3CardHands', () => {
+  it('trips beat pair', () => {
+    const trips: Card[] = [
+      { rank: Rank.Two, suit: s },
+      { rank: Rank.Two, suit: h },
+      { rank: Rank.Two, suit: d },
+    ];
+    const pair: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.Ace, suit: h },
+      { rank: Rank.King, suit: d },
+    ];
+    expect(compare3CardHands(trips, pair)).toBe(1);
+  });
+
+  it('pair beats high card', () => {
+    const pair: Card[] = [
+      { rank: Rank.Two, suit: s },
+      { rank: Rank.Two, suit: h },
+      { rank: Rank.Three, suit: d },
+    ];
+    const high: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.King, suit: h },
+      { rank: Rank.Queen, suit: d },
+    ];
+    expect(compare3CardHands(pair, high)).toBe(1);
+  });
+
+  it('higher kicker breaks pair tie', () => {
+    const pairWithAce: Card[] = [
+      { rank: Rank.Five, suit: s },
+      { rank: Rank.Five, suit: h },
+      { rank: Rank.Ace, suit: d },
+    ];
+    const pairWithKing: Card[] = [
+      { rank: Rank.Five, suit: d },
+      { rank: Rank.Five, suit: c },
+      { rank: Rank.King, suit: s },
+    ];
+    expect(compare3CardHands(pairWithAce, pairWithKing)).toBe(1);
+  });
+});
+
+describe('compareRows', () => {
+  it('uses 3-card eval for top row', () => {
+    const pairTop: Card[] = [
+      { rank: Rank.Two, suit: s },
+      { rank: Rank.Two, suit: h },
+      { rank: Rank.Three, suit: d },
+    ];
+    const highCardTop: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.King, suit: h },
+      { rank: Rank.Queen, suit: d },
+    ];
+    // Pair beats high card in 3-card eval
+    expect(compareRows(pairTop, highCardTop, true)).toBe(1);
+  });
+
+  it('uses 5-card eval for non-top rows', () => {
+    const flush: Card[] = [
+      { rank: Rank.Ace, suit: c },
+      { rank: Rank.Jack, suit: c },
+      { rank: Rank.Eight, suit: c },
+      { rank: Rank.Five, suit: c },
+      { rank: Rank.Three, suit: c },
+    ];
+    const twoPair: Card[] = [
+      { rank: Rank.Ace, suit: s },
+      { rank: Rank.Ace, suit: h },
+      { rank: Rank.King, suit: d },
+      { rank: Rank.King, suit: c },
+      { rank: Rank.Queen, suit: s },
+    ];
+    expect(compareRows(flush, twoPair, false)).toBe(1);
+  });
+});
+
+// ---- Hand ranking ordering ----
+
+describe('hand ranking ordering', () => {
+  const royalFlush: Card[] = [
+    { rank: Rank.Ace, suit: s },
+    { rank: Rank.King, suit: s },
+    { rank: Rank.Queen, suit: s },
+    { rank: Rank.Jack, suit: s },
+    { rank: Rank.Ten, suit: s },
+  ];
+  const straightFlush: Card[] = [
+    { rank: Rank.Nine, suit: h },
+    { rank: Rank.Eight, suit: h },
+    { rank: Rank.Seven, suit: h },
+    { rank: Rank.Six, suit: h },
+    { rank: Rank.Five, suit: h },
+  ];
+  const fourOfAKind: Card[] = [
+    { rank: Rank.Ace, suit: s },
+    { rank: Rank.Ace, suit: h },
+    { rank: Rank.Ace, suit: d },
+    { rank: Rank.Ace, suit: c },
+    { rank: Rank.King, suit: s },
+  ];
+  const fullHouse: Card[] = [
+    { rank: Rank.King, suit: s },
+    { rank: Rank.King, suit: h },
+    { rank: Rank.King, suit: d },
+    { rank: Rank.Queen, suit: c },
+    { rank: Rank.Queen, suit: s },
+  ];
+  const flush: Card[] = [
+    { rank: Rank.Ace, suit: c },
+    { rank: Rank.Jack, suit: c },
+    { rank: Rank.Eight, suit: c },
+    { rank: Rank.Five, suit: c },
+    { rank: Rank.Three, suit: c },
+  ];
+  const straight: Card[] = [
+    { rank: Rank.Ten, suit: s },
+    { rank: Rank.Nine, suit: h },
+    { rank: Rank.Eight, suit: d },
+    { rank: Rank.Seven, suit: c },
+    { rank: Rank.Six, suit: s },
+  ];
+  const threeOfAKind: Card[] = [
+    { rank: Rank.Seven, suit: s },
+    { rank: Rank.Seven, suit: h },
+    { rank: Rank.Seven, suit: d },
+    { rank: Rank.King, suit: c },
+    { rank: Rank.Two, suit: s },
+  ];
+  const twoPair: Card[] = [
+    { rank: Rank.Jack, suit: s },
+    { rank: Rank.Jack, suit: h },
+    { rank: Rank.Four, suit: d },
+    { rank: Rank.Four, suit: c },
+    { rank: Rank.Ace, suit: s },
+  ];
+  const onePair: Card[] = [
+    { rank: Rank.Nine, suit: s },
+    { rank: Rank.Nine, suit: h },
+    { rank: Rank.Ace, suit: d },
+    { rank: Rank.King, suit: c },
+    { rank: Rank.Two, suit: s },
+  ];
+  const highCard: Card[] = [
+    { rank: Rank.Ace, suit: s },
+    { rank: Rank.Ten, suit: h },
+    { rank: Rank.Eight, suit: d },
+    { rank: Rank.Five, suit: c },
+    { rank: Rank.Three, suit: h },
+  ];
+
+  const orderedHands = [
+    highCard,
+    onePair,
+    twoPair,
+    threeOfAKind,
+    straight,
+    flush,
+    fullHouse,
+    fourOfAKind,
+    straightFlush,
+    royalFlush,
+  ];
+
+  it('each hand beats all lower-ranked hands', () => {
+    for (let i = 0; i < orderedHands.length; i++) {
+      for (let j = i + 1; j < orderedHands.length; j++) {
+        expect(compare5CardHands(orderedHands[j], orderedHands[i])).toBe(1);
+        expect(compare5CardHands(orderedHands[i], orderedHands[j])).toBe(-1);
+      }
+    }
+  });
+});

--- a/shared/game-logic/scoring.test.ts
+++ b/shared/game-logic/scoring.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect } from 'vitest';
+import { isFoul, scorePairwise, scoreAllPlayers } from './scoring';
+import { FOUL_PENALTY, SCOOP_BONUS } from '../core/constants';
+import { Rank, Suit } from '../core/types';
+import type { Board, Card } from '../core/types';
+
+// -- Helpers --
+
+function card(rank: Rank, suit: Suit = Suit.Spades): Card {
+  return { rank, suit };
+}
+
+/** Build a valid (non-fouled) board: bottom > middle > top */
+function validBoard(): Board {
+  return {
+    top: [
+      card(Rank.Two, Suit.Spades),
+      card(Rank.Three, Suit.Hearts),
+      card(Rank.Four, Suit.Diamonds),
+    ],
+    middle: [
+      card(Rank.Six, Suit.Spades),
+      card(Rank.Six, Suit.Hearts),
+      card(Rank.Seven, Suit.Diamonds),
+      card(Rank.Eight, Suit.Clubs),
+      card(Rank.Nine, Suit.Spades),
+    ],
+    bottom: [
+      card(Rank.Ace, Suit.Spades),
+      card(Rank.Ace, Suit.Hearts),
+      card(Rank.King, Suit.Diamonds),
+      card(Rank.King, Suit.Clubs),
+      card(Rank.Queen, Suit.Spades),
+    ],
+  };
+}
+
+/** Build a fouled board: top stronger than middle */
+function fouledBoard(): Board {
+  return {
+    top: [
+      card(Rank.Ace, Suit.Spades),
+      card(Rank.Ace, Suit.Hearts),
+      card(Rank.Ace, Suit.Diamonds),
+    ],
+    middle: [
+      card(Rank.Two, Suit.Spades),
+      card(Rank.Three, Suit.Hearts),
+      card(Rank.Four, Suit.Diamonds),
+      card(Rank.Five, Suit.Clubs),
+      card(Rank.Seven, Suit.Spades),
+    ],
+    bottom: [
+      card(Rank.King, Suit.Spades),
+      card(Rank.King, Suit.Hearts),
+      card(Rank.King, Suit.Diamonds),
+      card(Rank.King, Suit.Clubs),
+      card(Rank.Queen, Suit.Spades),
+    ],
+  };
+}
+
+/** Build a second valid board that's weaker than validBoard */
+function weakerValidBoard(): Board {
+  return {
+    top: [
+      card(Rank.Two, Suit.Clubs),
+      card(Rank.Three, Suit.Diamonds),
+      card(Rank.Five, Suit.Hearts),
+    ],
+    middle: [
+      card(Rank.Four, Suit.Spades),
+      card(Rank.Four, Suit.Hearts),
+      card(Rank.Six, Suit.Diamonds),
+      card(Rank.Seven, Suit.Clubs),
+      card(Rank.Eight, Suit.Hearts),
+    ],
+    bottom: [
+      card(Rank.Jack, Suit.Spades),
+      card(Rank.Jack, Suit.Hearts),
+      card(Rank.Ten, Suit.Diamonds),
+      card(Rank.Ten, Suit.Clubs),
+      card(Rank.Nine, Suit.Spades),
+    ],
+  };
+}
+
+/** Build a board that beats validBoard on all 3 rows for scoop testing */
+function strongBoard(): Board {
+  return {
+    top: [
+      card(Rank.King, Suit.Spades),
+      card(Rank.King, Suit.Hearts),
+      card(Rank.Two, Suit.Diamonds),
+    ],
+    middle: [
+      card(Rank.Ace, Suit.Spades),
+      card(Rank.Ace, Suit.Hearts),
+      card(Rank.Ace, Suit.Diamonds),
+      card(Rank.Three, Suit.Clubs),
+      card(Rank.Three, Suit.Spades),
+    ],
+    bottom: [
+      card(Rank.Ace, Suit.Clubs),
+      card(Rank.King, Suit.Diamonds),
+      card(Rank.King, Suit.Clubs),
+      card(Rank.Queen, Suit.Diamonds),
+      card(Rank.Queen, Suit.Hearts),
+    ],
+  };
+}
+
+// ---- isFoul ----
+
+describe('isFoul', () => {
+  it('returns false for a valid board', () => {
+    expect(isFoul(validBoard())).toBe(false);
+  });
+
+  it('returns true when top is stronger than middle', () => {
+    expect(isFoul(fouledBoard())).toBe(true);
+  });
+
+  it('returns false for incomplete boards (game in progress)', () => {
+    const incomplete: Board = {
+      top: [card(Rank.Ace)],
+      middle: [],
+      bottom: [],
+    };
+    expect(isFoul(incomplete)).toBe(false);
+  });
+
+  it('returns false when top has fewer than 3 cards', () => {
+    const board: Board = {
+      top: [card(Rank.Ace), card(Rank.King)],
+      middle: [card(Rank.Two), card(Rank.Three), card(Rank.Four), card(Rank.Five), card(Rank.Six)],
+      bottom: [card(Rank.Seven), card(Rank.Eight), card(Rank.Nine), card(Rank.Ten), card(Rank.Jack)],
+    };
+    expect(isFoul(board)).toBe(false);
+  });
+
+  it('returns true when bottom is weaker than middle', () => {
+    const board: Board = {
+      top: [
+        card(Rank.Two, Suit.Spades),
+        card(Rank.Three, Suit.Hearts),
+        card(Rank.Four, Suit.Diamonds),
+      ],
+      middle: [
+        card(Rank.Ace, Suit.Spades),
+        card(Rank.Ace, Suit.Hearts),
+        card(Rank.King, Suit.Diamonds),
+        card(Rank.King, Suit.Clubs),
+        card(Rank.Queen, Suit.Spades),
+      ],
+      bottom: [
+        card(Rank.Six, Suit.Spades),
+        card(Rank.Six, Suit.Hearts),
+        card(Rank.Seven, Suit.Diamonds),
+        card(Rank.Eight, Suit.Clubs),
+        card(Rank.Nine, Suit.Spades),
+      ],
+    };
+    expect(isFoul(board)).toBe(true);
+  });
+
+  it('returns true when middle equals top (must be strictly greater)', () => {
+    // Both have pair of 5s. Top kicker is King, middle highest non-pair kicker is also King.
+    // Kicker comparison ties at min length → treated as equal → foul (must be strictly greater).
+    const board: Board = {
+      top: [
+        card(Rank.Five, Suit.Spades),
+        card(Rank.Five, Suit.Hearts),
+        card(Rank.King, Suit.Diamonds),
+      ],
+      middle: [
+        card(Rank.Five, Suit.Diamonds),
+        card(Rank.Five, Suit.Clubs),
+        card(Rank.King, Suit.Spades),
+        card(Rank.Three, Suit.Hearts),
+        card(Rank.Two, Suit.Diamonds),
+      ],
+      bottom: [
+        card(Rank.Ace, Suit.Spades),
+        card(Rank.Ace, Suit.Hearts),
+        card(Rank.Ace, Suit.Diamonds),
+        card(Rank.King, Suit.Clubs),
+        card(Rank.Queen, Suit.Spades),
+      ],
+    };
+    expect(isFoul(board)).toBe(true);
+  });
+});
+
+// ---- scorePairwise ----
+
+describe('scorePairwise', () => {
+  it('both fouled: 0 points', () => {
+    const board = validBoard();
+    const result = scorePairwise('a', true, board, 'b', true, board);
+    expect(result.total).toBe(0);
+    expect(result.rowPoints).toBe(0);
+    expect(result.scoopBonus).toBe(0);
+  });
+
+  it('A fouled: A gets -FOUL_PENALTY', () => {
+    const result = scorePairwise('a', true, validBoard(), 'b', false, validBoard());
+    expect(result.total).toBe(-FOUL_PENALTY);
+    expect(result.rowPoints).toBe(-FOUL_PENALTY);
+    expect(result.scoopBonus).toBe(0);
+    expect(result.playerA).toBe('a');
+    expect(result.playerB).toBe('b');
+  });
+
+  it('B fouled: A gets +FOUL_PENALTY', () => {
+    const result = scorePairwise('a', false, validBoard(), 'b', true, validBoard());
+    expect(result.total).toBe(FOUL_PENALTY);
+    expect(result.rowPoints).toBe(FOUL_PENALTY);
+  });
+
+  it('neither fouled: row-by-row comparison', () => {
+    const strong = validBoard();
+    const weak = weakerValidBoard();
+    const result = scorePairwise('a', false, strong, 'b', false, weak);
+    // validBoard wins middle (pair 6s > pair 4s) and bottom (two pair A+K > two pair J+T)
+    // but loses top (high card [4,3,2] < high card [5,3,2])
+    // rowPoints = -1 + 1 + 1 = 1, no scoop
+    expect(result.rowPoints).toBe(1);
+    expect(result.scoopBonus).toBe(0);
+    expect(result.total).toBe(1);
+  });
+
+  it('scoop for winning all 3 rows', () => {
+    const strong = strongBoard();
+    const weak = weakerValidBoard();
+    const result = scorePairwise('a', false, strong, 'b', false, weak);
+    expect(result.scoopBonus).toBe(SCOOP_BONUS);
+    expect(result.total).toBe(result.rowPoints + SCOOP_BONUS);
+  });
+
+  it('negative scoop when losing all 3 rows', () => {
+    const strong = strongBoard();
+    const weak = weakerValidBoard();
+    const result = scorePairwise('b', false, weak, 'a', false, strong);
+    expect(result.scoopBonus).toBe(-SCOOP_BONUS);
+  });
+
+  it('identical boards: 0 points', () => {
+    const board = validBoard();
+    const result = scorePairwise('a', false, board, 'b', false, board);
+    expect(result.total).toBe(0);
+    expect(result.rowPoints).toBe(0);
+    expect(result.scoopBonus).toBe(0);
+  });
+});
+
+// ---- scoreAllPlayers ----
+
+describe('scoreAllPlayers', () => {
+  it('scores two players correctly', () => {
+    const boards = new Map<string, Board>();
+    boards.set('a', validBoard());
+    boards.set('b', weakerValidBoard());
+
+    const fouls = new Map<string, boolean>();
+    fouls.set('a', false);
+    fouls.set('b', false);
+
+    const result = scoreAllPlayers(boards, fouls);
+    expect(result.players).toHaveLength(2);
+
+    const playerA = result.players.find((p) => p.uid === 'a')!;
+    const playerB = result.players.find((p) => p.uid === 'b')!;
+
+    // Zero-sum: scores should be equal and opposite
+    expect(playerA.netScore + playerB.netScore).toBe(0);
+    expect(playerA.netScore).toBeGreaterThan(0);
+  });
+
+  it('scores three players correctly', () => {
+    const boards = new Map<string, Board>();
+    boards.set('a', strongBoard());
+    boards.set('b', validBoard());
+    boards.set('c', weakerValidBoard());
+
+    const fouls = new Map<string, boolean>();
+    fouls.set('a', false);
+    fouls.set('b', false);
+    fouls.set('c', false);
+
+    const result = scoreAllPlayers(boards, fouls);
+    expect(result.players).toHaveLength(3);
+
+    // Sum of all scores should be 0 (zero-sum game)
+    const totalScore = result.players.reduce((sum, p) => sum + p.netScore, 0);
+    expect(totalScore).toBe(0);
+  });
+
+  it('handles fouled players', () => {
+    const boards = new Map<string, Board>();
+    boards.set('a', validBoard());
+    boards.set('b', fouledBoard());
+
+    const fouls = new Map<string, boolean>();
+    fouls.set('a', false);
+    fouls.set('b', true);
+
+    const result = scoreAllPlayers(boards, fouls);
+    const playerA = result.players.find((p) => p.uid === 'a')!;
+    const playerB = result.players.find((p) => p.uid === 'b')!;
+
+    expect(playerA.netScore).toBe(FOUL_PENALTY);
+    expect(playerB.netScore).toBe(-FOUL_PENALTY);
+    expect(playerB.fouled).toBe(true);
+  });
+
+  it('each player has pairwise results', () => {
+    const boards = new Map<string, Board>();
+    boards.set('a', validBoard());
+    boards.set('b', weakerValidBoard());
+    boards.set('c', strongBoard());
+
+    const fouls = new Map<string, boolean>();
+    fouls.set('a', false);
+    fouls.set('b', false);
+    fouls.set('c', false);
+
+    const result = scoreAllPlayers(boards, fouls);
+    // Each player plays against 2 opponents
+    for (const player of result.players) {
+      expect(player.pairwise).toHaveLength(2);
+    }
+  });
+
+  it('pairwise results are properly inverted between players', () => {
+    const boards = new Map<string, Board>();
+    boards.set('a', validBoard());
+    boards.set('b', weakerValidBoard());
+
+    const fouls = new Map<string, boolean>();
+    fouls.set('a', false);
+    fouls.set('b', false);
+
+    const result = scoreAllPlayers(boards, fouls);
+    const playerA = result.players.find((p) => p.uid === 'a')!;
+    const playerB = result.players.find((p) => p.uid === 'b')!;
+
+    const aVsB = playerA.pairwise[0];
+    const bVsA = playerB.pairwise[0];
+
+    expect(aVsB.total).toBe(-bVsA.total);
+    expect(aVsB.rowPoints).toBe(-bVsA.rowPoints);
+    expect(aVsB.scoopBonus).toBe(-bVsA.scoopBonus);
+  });
+});

--- a/shared/vitest.config.ts
+++ b/shared/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.test.ts'],
+    root: '.',
+  },
+});


### PR DESCRIPTION
Set up vitest and add 79 unit tests covering all shared modules:
- deck.ts: creation, shuffling, dealing
- hand-evaluation.ts: all hand types, 3-card/5-card eval, comparisons
- scoring.ts: foul detection, pairwise scoring, multi-player scoring
- board-utils.ts: empty board, phase mapping
- firestore-paths.ts: path helpers

https://claude.ai/code/session_0186fBqJfrn8V1g7fG4uFgfa