### PR TITLE
Add cost safeguards: game cleanup + maxInstances caps

### DIFF
--- a/functions/src/cleanup.ts
+++ b/functions/src/cleanup.ts
@@ -1,0 +1,40 @@
+import { onSchedule } from 'firebase-functions/v2/scheduler';
+import * as admin from 'firebase-admin';
+import * as logger from 'firebase-functions/logger';
+
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const pruneOldGames = onSchedule({ schedule: 'every 24 hours', maxInstances: 1 }, async () => {
+  const db = admin.firestore();
+  const cutoff = Date.now() - SEVEN_DAYS_MS;
+
+  const staleGames = await db
+    .collection('games')
+    .where('updatedAt', '<', cutoff)
+    .get();
+
+  if (staleGames.empty) {
+    logger.info('pruneOldGames: no stale games found');
+    return;
+  }
+
+  const writer = db.bulkWriter();
+  let count = 0;
+
+  for (const gameDoc of staleGames.docs) {
+    const roomId = gameDoc.id;
+
+    const [hands, decks] = await Promise.all([
+      db.collection(`games/${roomId}/hands`).listDocuments(),
+      db.collection(`games/${roomId}/decks`).listDocuments(),
+    ]);
+
+    for (const doc of hands) writer.delete(doc);
+    for (const doc of decks) writer.delete(doc);
+    writer.delete(gameDoc.ref);
+    count++;
+  }
+
+  await writer.close();
+  logger.info(`pruneOldGames: deleted ${count} stale games`);
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -3,3 +3,4 @@ import * as admin from 'firebase-admin';
 admin.initializeApp();
 
 export { joinGame, leaveGame, placeCards, startMatch, playAgain } from './player-actions';
+export { pruneOldGames } from './cleanup';

--- a/functions/src/player-actions.ts
+++ b/functions/src/player-actions.ts
@@ -71,7 +71,7 @@ async function removePlayer(uid: string, roomId: string): Promise<void> {
 
 // ---- joinGame ----
 
-export const joinGame = onCall(async (request) => {
+export const joinGame = onCall({ maxInstances: 10 }, async (request) => {
   const uid = request.auth?.uid;
   if (!uid) {
     throw new HttpsError('unauthenticated', 'Must be signed in to join.');
@@ -160,7 +160,7 @@ export const joinGame = onCall(async (request) => {
 
 // ---- leaveGame ----
 
-export const leaveGame = onCall(async (request) => {
+export const leaveGame = onCall({ maxInstances: 10 }, async (request) => {
   const uid = request.auth?.uid;
   if (!uid) {
     throw new HttpsError('unauthenticated', 'Must be signed in.');
@@ -182,7 +182,7 @@ interface PlaceCardsData {
   discard?: Card;
 }
 
-export const placeCards = onCall(async (request) => {
+export const placeCards = onCall({ maxInstances: 10 }, async (request) => {
   const uid = request.auth?.uid;
   if (!uid) {
     throw new HttpsError('unauthenticated', 'Must be signed in.');
@@ -319,7 +319,7 @@ export const placeCards = onCall(async (request) => {
 
 // ---- startMatch ----
 
-export const startMatch = onCall(async (request) => {
+export const startMatch = onCall({ maxInstances: 10 }, async (request) => {
   const uid = request.auth?.uid;
   if (!uid) {
     throw new HttpsError('unauthenticated', 'Must be signed in.');
@@ -363,7 +363,7 @@ export const startMatch = onCall(async (request) => {
 
 // ---- playAgain ----
 
-export const playAgain = onCall(async (request) => {
+export const playAgain = onCall({ maxInstances: 10 }, async (request) => {
   const uid = request.auth?.uid;
   if (!uid) {
     throw new HttpsError('unauthenticated', 'Must be signed in.');


### PR DESCRIPTION
## Summary
- **Scheduled cleanup function**: `pruneOldGames` runs daily, deletes games with `updatedAt` older than 7 days (including `hands/` and `decks/` subcollections) using `bulkWriter()`
- **maxInstances caps**: All 5 `onCall` functions capped at 10 concurrent instances; `pruneOldGames` capped at 1
- **GCP budget alert**: $10/month budget created via `gcloud` CLI with email alerts at 50%, 90%, 100% (already applied, not in code)

## Test plan
- [ ] `npm run build -w functions` compiles clean
- [ ] CI passes
- [ ] After merge + deploy, verify `pruneOldGames` visible in Firebase Console > Functions
- [ ] Verify Cloud Scheduler job in GCP Console
- [ ] Verify budget alert in GCP Console > Billing > Budgets & alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)