### PR TITLE
Add post-deploy E2E smoke tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,28 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      firebase: ${{ steps.check.outputs.firebase }}
+      dealer: ${{ steps.check.outputs.dealer }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - id: check
+        run: |
+          CHANGED=$(git diff --name-only HEAD~1)
+          FIREBASE=$(echo "$CHANGED" | grep -qE '^(frontend/|functions/|shared/|firestore\.rules|firebase\.json)' && echo true || echo false)
+          DEALER=$(echo "$CHANGED" | grep -qE '^(dealer/|shared/)' && echo true || echo false)
+          echo "firebase=$FIREBASE" >> "$GITHUB_OUTPUT"
+          echo "dealer=$DEALER" >> "$GITHUB_OUTPUT"
+          echo "Deploy firebase: $FIREBASE, Deploy dealer: $DEALER"
+
   deploy-firebase:
+    needs: changes
+    if: needs.changes.outputs.firebase == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +61,8 @@ jobs:
         run: rm -f /tmp/sa-key.json
 
   deploy-dealer:
+    needs: changes
+    if: needs.changes.outputs.dealer == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -103,3 +126,25 @@ jobs:
       - name: Clean up SSH key
         if: always()
         run: rm -f ~/.ssh/deploy_key
+
+  smoke-test:
+    needs: [changes, deploy-firebase, deploy-dealer]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests against production
+        env:
+          PRODUCTION_URL: https://pineapple-poker-8f3.web.app
+        run: npx playwright test

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,24 +1,31 @@
 /**
- * Playwright globalSetup — fail fast if dev services aren't running.
+ * Playwright globalSetup — fail fast if required services aren't running.
+ *
+ * When PRODUCTION_URL is set, only checks that the production site is reachable.
+ * Otherwise, checks all local emulator services.
  */
 export default async function globalSetup() {
-  const checks = [
-    { name: 'Firestore emulator', url: 'http://localhost:8080' },
-    { name: 'Functions emulator', url: 'http://localhost:5001', anyStatus: true },
-    { name: 'Emulator UI', url: 'http://localhost:4000' },
-    { name: 'Vite dev server', url: 'http://localhost:5173' },
-    { name: 'Dealer service', url: 'http://localhost:5555/health' },
-  ];
+  const productionUrl = process.env.PRODUCTION_URL;
+
+  const checks = productionUrl
+    ? [{ name: 'Production site', url: productionUrl }]
+    : [
+        { name: 'Firestore emulator', url: 'http://localhost:8080' },
+        { name: 'Functions emulator', url: 'http://localhost:5001', anyStatus: true },
+        { name: 'Emulator UI', url: 'http://localhost:4000' },
+        { name: 'Vite dev server', url: 'http://localhost:5173' },
+        { name: 'Dealer service', url: 'http://localhost:5555/health' },
+      ];
 
   const failures: string[] = [];
 
   for (const check of checks) {
     try {
       const controller = new AbortController();
-      const timeout = setTimeout(() => controller.abort(), 2000);
+      const timeout = setTimeout(() => controller.abort(), 5000);
       const res = await fetch(check.url, { signal: controller.signal });
       clearTimeout(timeout);
-      if (!check.anyStatus && !res.ok) {
+      if (!('anyStatus' in check && check.anyStatus) && !res.ok) {
         failures.push(`${check.name} (${check.url}) — HTTP ${res.status}`);
       }
     } catch {
@@ -27,13 +34,17 @@ export default async function globalSetup() {
   }
 
   if (failures.length > 0) {
+    const hint = productionUrl
+      ? 'Check that the production site is deployed and accessible.'
+      : 'Start all services with:  npm run dev:up';
+
     const msg = [
       '',
       'E2E pre-flight check failed. These services are not running:',
       '',
       ...failures.map((f) => `  ✗ ${f}`),
       '',
-      'Start all services with:  npm run dev:up',
+      hint,
       '',
     ].join('\n');
     throw new Error(msg);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,13 +1,15 @@
 import { defineConfig } from '@playwright/test';
 
+const isProduction = !!process.env.PRODUCTION_URL;
+
 export default defineConfig({
   globalSetup: './e2e/global-setup.ts',
   testDir: './e2e',
   timeout: 120_000,
-  retries: 0,
+  retries: isProduction ? 1 : 0,
   workers: undefined, /* parallel — each test uses a unique room */
   use: {
-    baseURL: 'http://localhost:5173',
+    baseURL: process.env.PRODUCTION_URL || 'http://localhost:5173',
     headless: true,
     viewport: { width: 1280, height: 900 },
   },


### PR DESCRIPTION
## Summary
- Adds a `smoke-test` job to the deploy workflow that runs E2E tests against production after deploy
- Adds path-based change detection so deploys only run when relevant code changes (skips unnecessary Firebase/dealer deploys for CI-only changes)
- Makes Playwright config and global setup production-aware via `PRODUCTION_URL` env var

## Test plan
- [ ] Verify CI passes on this PR (no deploy triggered)
- [ ] After merge, confirm deploy workflow skips both deploys and runs smoke-test directly
- [ ] On a future app code change, confirm deploys run then smoke-test follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)