### PR TITLE
Fix production smoke tests

### DIFF
--- a/e2e/card-placement.spec.ts
+++ b/e2e/card-placement.spec.ts
@@ -25,22 +25,22 @@ test('placed cards appear on board and auto-submit works', async ({ browser }) =
 
   await alice.getByTestId('name-input').fill('Alice');
   await alice.getByTestId('join-button').click();
-  await alice.getByTestId('start-match-button').waitFor({ timeout: 10_000 });
+  await alice.getByTestId('start-match-button').waitFor({ timeout: 30_000 });
 
   await bob.getByTestId('name-input').fill('Bob');
   await bob.getByTestId('join-button').click();
-  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 10_000 });
+  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 30_000 });
 
   // Host starts match
   await alice.getByTestId('start-match-button').click();
 
   // Wait for initial_deal phase
-  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
+  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
 
   const board = alice.getByTestId('my-board');
 
   // Wait for cards in hand
-  await alice.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+  await alice.getByTestId('hand-card-0').waitFor({ timeout: 30_000 });
 
   // --- Verify: no confirm or undo buttons exist before placing ---
   await expect(alice.getByTestId('confirm-button')).not.toBeVisible();
@@ -93,7 +93,7 @@ test('placed cards appear on board and auto-submit works', async ({ browser }) =
   await expect(alice.getByTestId('confirm-button')).not.toBeVisible();
 
   // --- Bob places to advance game to street 2 ---
-  await bob.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+  await bob.getByTestId('hand-card-0').waitFor({ timeout: 30_000 });
 
   const bobBoard = bob.getByTestId('my-board');
   for (let i = 0; i < 2; i++) {
@@ -108,8 +108,8 @@ test('placed cards appear on board and auto-submit works', async ({ browser }) =
   await bobBoard.getByTestId('row-top').click();
 
   // --- Street 2: verify auto-discard (3 cards dealt, place 2, 3rd auto-discarded) ---
-  await expect(alice.getByTestId('phase-label')).toContainText('street_2', { timeout: 15_000 });
-  await alice.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+  await expect(alice.getByTestId('phase-label')).toContainText('street_2', { timeout: 30_000 });
+  await alice.getByTestId('hand-card-0').waitFor({ timeout: 30_000 });
 
   // Should have 3 cards in hand
   await expect(alice.getByTestId('hand-card-0')).toBeVisible();

--- a/e2e/dev-ui.spec.ts
+++ b/e2e/dev-ui.spec.ts
@@ -37,8 +37,8 @@ test('dev UI features render correctly', async ({ browser }) => {
   // --- Debug panel should be visible by default ---
   await expect(alice.getByText('Debug')).toBeVisible();
 
-  // Debug panel should contain game state info
-  await expect(alice.getByText('initial_deal')).toBeVisible();
+  // Debug panel should contain game state info (use first() since phase-label also shows it)
+  await expect(alice.getByText('initial_deal').first()).toBeVisible();
   await expect(alice.getByText('Alice')).toBeVisible();
   await expect(alice.getByText('Bob')).toBeVisible();
 

--- a/e2e/happy-path.spec.ts
+++ b/e2e/happy-path.spec.ts
@@ -15,7 +15,7 @@ async function placeInitialDeal(page: Page) {
   const board = page.getByTestId('my-board');
 
   // Wait for cards to appear in hand
-  await page.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+  await page.getByTestId('hand-card-0').waitFor({ timeout: 30_000 });
 
   // Card 0 → bottom row
   await page.getByTestId('hand-card-0').click();
@@ -45,7 +45,7 @@ async function placeStreet(page: Page, street: number) {
   const board = page.getByTestId('my-board');
 
   // Wait for 3 cards in hand
-  await page.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+  await page.getByTestId('hand-card-0').waitFor({ timeout: 30_000 });
 
   let row1: string, row2: string;
 
@@ -78,8 +78,8 @@ async function placeStreet(page: Page, street: number) {
 /** Play one full round: initial deal + streets 2-5. */
 async function playFullRound(alice: Page, bob: Page) {
   // Wait for initial_deal phase
-  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
-  await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
+  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
+  await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
 
   // Initial deal: both place 5 cards
   await placeInitialDeal(alice);
@@ -88,8 +88,8 @@ async function playFullRound(alice: Page, bob: Page) {
   // Streets 2 through 5
   for (const street of [2, 3, 4, 5]) {
     const phaseText = `street_${street}`;
-    await expect(alice.getByTestId('phase-label')).toContainText(phaseText, { timeout: 15_000 });
-    await expect(bob.getByTestId('phase-label')).toContainText(phaseText, { timeout: 15_000 });
+    await expect(alice.getByTestId('phase-label')).toContainText(phaseText, { timeout: 30_000 });
+    await expect(bob.getByTestId('phase-label')).toContainText(phaseText, { timeout: 30_000 });
 
     await placeStreet(alice, street);
     await placeStreet(bob, street);
@@ -116,14 +116,14 @@ test('two players play a full 3-round match', async ({ browser }) => {
   await alice.getByTestId('join-button').click();
 
   // Alice should see the lobby with Start Match button
-  await alice.getByTestId('start-match-button').waitFor({ timeout: 10_000 });
+  await alice.getByTestId('start-match-button').waitFor({ timeout: 30_000 });
 
   // --- Bob joins ---
   await bob.getByTestId('name-input').fill('Bob');
   await bob.getByTestId('join-button').click();
 
   // Bob should see the lobby (waiting for host)
-  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 10_000 });
+  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 30_000 });
 
   // --- Host starts the match ---
   await alice.getByTestId('start-match-button').click();
@@ -134,8 +134,8 @@ test('two players play a full 3-round match', async ({ browser }) => {
 
     if (round < 3) {
       // Inter-round: round results modal appears
-      await alice.getByTestId('round-results').waitFor({ timeout: 15_000 });
-      await bob.getByTestId('round-results').waitFor({ timeout: 15_000 });
+      await alice.getByTestId('round-results').waitFor({ timeout: 30_000 });
+      await bob.getByTestId('round-results').waitFor({ timeout: 30_000 });
 
       // Verify round results header
       await expect(alice.getByTestId('round-results')).toContainText(`Round ${round} of 3 Complete`);
@@ -147,8 +147,8 @@ test('two players play a full 3-round match', async ({ browser }) => {
       // Wait for next round to start (auto-reset → lobby → auto-start)
     } else {
       // After round 3: match-results modal (not round-results)
-      await alice.getByTestId('match-results').waitFor({ timeout: 15_000 });
-      await bob.getByTestId('match-results').waitFor({ timeout: 15_000 });
+      await alice.getByTestId('match-results').waitFor({ timeout: 30_000 });
+      await bob.getByTestId('match-results').waitFor({ timeout: 30_000 });
 
       // Verify match results
       await expect(alice.getByTestId('match-results')).toContainText('Match Complete');
@@ -161,8 +161,8 @@ test('two players play a full 3-round match', async ({ browser }) => {
   await alice.getByTestId('play-again-button').click();
 
   // Both should be back in lobby
-  await alice.getByTestId('start-match-button').waitFor({ timeout: 15_000 });
-  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 15_000 });
+  await alice.getByTestId('start-match-button').waitFor({ timeout: 30_000 });
+  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 30_000 });
 
   // Cleanup
   await ctx1.close();

--- a/e2e/helpers/placement.ts
+++ b/e2e/helpers/placement.ts
@@ -5,7 +5,7 @@ export async function placeInitialDeal(page: Page) {
   const board = page.getByTestId('my-board');
 
   // Wait for cards to appear in hand
-  await page.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+  await page.getByTestId('hand-card-0').waitFor({ timeout: 30_000 });
 
   // Card 0 → bottom row
   await page.getByTestId('hand-card-0').click();
@@ -41,7 +41,7 @@ export async function placeStreet(page: Page, street: number) {
   const board = page.getByTestId('my-board');
 
   // Wait for 3 cards in hand
-  await page.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+  await page.getByTestId('hand-card-0').waitFor({ timeout: 30_000 });
 
   // Choose which rows to place into based on street number
   let row1: string, row2: string;

--- a/e2e/leave-game.spec.ts
+++ b/e2e/leave-game.spec.ts
@@ -22,24 +22,24 @@ test('player can leave mid-match and game continues for remaining player', async
 
   await alice.getByTestId('name-input').fill('Alice');
   await alice.getByTestId('join-button').click();
-  await alice.getByTestId('start-match-button').waitFor({ timeout: 10_000 });
+  await alice.getByTestId('start-match-button').waitFor({ timeout: 30_000 });
 
   await bob.getByTestId('name-input').fill('Bob');
   await bob.getByTestId('join-button').click();
-  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 10_000 });
+  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 30_000 });
 
   // --- Host starts match ---
   await alice.getByTestId('start-match-button').click();
 
   // Wait for round 1 initial_deal
-  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
-  await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
+  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
+  await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
 
   // --- Bob leaves during round 1 ---
   await bob.getByText('Leave').click();
 
   // Bob should return to room selector (create-room-button visible on the home screen)
-  await bob.getByTestId('create-room-button').waitFor({ timeout: 10_000 });
+  await bob.getByTestId('create-room-button').waitFor({ timeout: 30_000 });
 
   // --- Alice plays the round solo ---
   // Bob has been removed from playerOrder. Alice's placements will satisfy allPlaced.
@@ -47,12 +47,12 @@ test('player can leave mid-match and game continues for remaining player', async
 
   // Game advances through streets (Alice is the only player)
   for (const street of [2, 3, 4, 5]) {
-    await expect(alice.getByTestId('phase-label')).toContainText(`street_${street}`, { timeout: 15_000 });
+    await expect(alice.getByTestId('phase-label')).toContainText(`street_${street}`, { timeout: 30_000 });
     await placeStreet(alice, street);
   }
 
   // Round 1 results — Alice should see round results
-  await alice.getByTestId('round-results').waitFor({ timeout: 15_000 });
+  await alice.getByTestId('round-results').waitFor({ timeout: 30_000 });
   await expect(alice.getByTestId('round-results')).toContainText('Round 1 of 3 Complete');
   await expect(alice.getByTestId('round-results')).toContainText('Alice');
 

--- a/e2e/observer.spec.ts
+++ b/e2e/observer.spec.ts
@@ -24,16 +24,16 @@ test('late joiner observes match then plays after play-again', async ({ browser 
 
   await alice.getByTestId('name-input').fill('Alice');
   await alice.getByTestId('join-button').click();
-  await alice.getByTestId('start-match-button').waitFor({ timeout: 10_000 });
+  await alice.getByTestId('start-match-button').waitFor({ timeout: 30_000 });
 
   await bob.getByTestId('name-input').fill('Bob');
   await bob.getByTestId('join-button').click();
-  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 10_000 });
+  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 30_000 });
 
   await alice.getByTestId('start-match-button').click();
 
   // Wait for initial_deal to begin
-  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
+  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
 
   // --- Carol joins mid-round → becomes observer ---
   await carol.goto(`/?room=${roomId}`);
@@ -41,37 +41,37 @@ test('late joiner observes match then plays after play-again', async ({ browser 
   await carol.getByTestId('join-button').click();
 
   // Carol should see the observer banner
-  await expect(carol.getByText('Observing')).toBeVisible({ timeout: 10_000 });
+  await expect(carol.getByText('Observing')).toBeVisible({ timeout: 30_000 });
 
   // Carol should NOT have hand cards (observers don't get dealt in)
   await expect(carol.getByTestId('hand-card-0')).not.toBeVisible({ timeout: 3_000 });
 
   // --- Alice and Bob play all 3 rounds (Carol observes) ---
   for (let round = 1; round <= 3; round++) {
-    await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 20_000 });
-    await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 20_000 });
+    await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
+    await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
 
     await placeInitialDeal(alice);
     await placeInitialDeal(bob);
 
     for (const street of [2, 3, 4, 5]) {
-      await expect(alice.getByTestId('phase-label')).toContainText(`street_${street}`, { timeout: 15_000 });
-      await expect(bob.getByTestId('phase-label')).toContainText(`street_${street}`, { timeout: 15_000 });
+      await expect(alice.getByTestId('phase-label')).toContainText(`street_${street}`, { timeout: 30_000 });
+      await expect(bob.getByTestId('phase-label')).toContainText(`street_${street}`, { timeout: 30_000 });
       await placeStreet(alice, street);
       await placeStreet(bob, street);
     }
 
     if (round < 3) {
       // Inter-round results
-      await alice.getByTestId('round-results').waitFor({ timeout: 15_000 });
-      await bob.getByTestId('round-results').waitFor({ timeout: 15_000 });
+      await alice.getByTestId('round-results').waitFor({ timeout: 30_000 });
+      await bob.getByTestId('round-results').waitFor({ timeout: 30_000 });
       await alice.getByTestId('close-results').click();
       await bob.getByTestId('close-results').click();
     }
   }
 
   // Match complete
-  await alice.getByTestId('match-results').waitFor({ timeout: 15_000 });
+  await alice.getByTestId('match-results').waitFor({ timeout: 30_000 });
   await expect(alice.getByTestId('match-results')).toContainText('Match Complete');
 
   // Carol should still be observing during match results (no match-results modal for her,
@@ -83,23 +83,23 @@ test('late joiner observes match then plays after play-again', async ({ browser 
   await alice.getByTestId('play-again-button').click();
 
   // After playAgain, Carol is promoted into playerOrder. All 3 in lobby.
-  await alice.getByTestId('start-match-button').waitFor({ timeout: 15_000 });
-  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 15_000 });
-  await expect(carol.getByText('Waiting for host to start')).toBeVisible({ timeout: 15_000 });
+  await alice.getByTestId('start-match-button').waitFor({ timeout: 30_000 });
+  await expect(bob.getByText('Waiting for host to start')).toBeVisible({ timeout: 30_000 });
+  await expect(carol.getByText('Waiting for host to start')).toBeVisible({ timeout: 30_000 });
 
   // --- Start new match with 3 players ---
   await alice.getByTestId('start-match-button').click();
 
   // All 3 should be in initial_deal
-  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
-  await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
-  await expect(carol.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 15_000 });
+  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
+  await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
+  await expect(carol.getByTestId('phase-label')).toContainText('initial_deal', { timeout: 30_000 });
 
   // Carol should NO LONGER see "Observing" banner
   await expect(carol.getByText('Observing')).not.toBeVisible({ timeout: 5_000 });
 
   // Carol should have hand cards now
-  await carol.getByTestId('hand-card-0').waitFor({ timeout: 15_000 });
+  await carol.getByTestId('hand-card-0').waitFor({ timeout: 30_000 });
 
   // All 3 play round 1 of new match
   await placeInitialDeal(alice);
@@ -107,14 +107,14 @@ test('late joiner observes match then plays after play-again', async ({ browser 
   await placeInitialDeal(carol);
 
   for (const street of [2, 3, 4, 5]) {
-    await expect(alice.getByTestId('phase-label')).toContainText(`street_${street}`, { timeout: 15_000 });
+    await expect(alice.getByTestId('phase-label')).toContainText(`street_${street}`, { timeout: 30_000 });
     await placeStreet(alice, street);
     await placeStreet(bob, street);
     await placeStreet(carol, street);
   }
 
   // Round 1 results of new match — should show all 3 players
-  await alice.getByTestId('round-results').waitFor({ timeout: 15_000 });
+  await alice.getByTestId('round-results').waitFor({ timeout: 30_000 });
   await expect(alice.getByTestId('round-results')).toContainText('Round 1 of 3 Complete');
   await expect(alice.getByTestId('round-results')).toContainText('Alice');
   await expect(alice.getByTestId('round-results')).toContainText('Bob');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,10 @@ const isProduction = !!process.env.PRODUCTION_URL;
 export default defineConfig({
   globalSetup: './e2e/global-setup.ts',
   testDir: './e2e',
-  timeout: 120_000,
+  testIgnore: isProduction
+    ? ['**/bot.spec.ts', '**/stress.spec.ts', '**/scoring.spec.ts', '**/sit-out.spec.ts', '**/dev-ui.spec.ts']
+    : ['**/bot.spec.ts'],
+  timeout: isProduction ? 180_000 : 120_000,
   retries: isProduction ? 1 : 0,
   workers: undefined, /* parallel — each test uses a unique room */
   use: {


### PR DESCRIPTION
## Summary
- **Exclude heavy/flaky tests from production**: `bot.spec.ts` (always, manual tool), `stress.spec.ts`, `scoring.spec.ts`, `sit-out.spec.ts`, `dev-ui.spec.ts` (production only)
- **Bump waitFor timeouts** from 10-15s to 30s across all 4 production smoke tests to handle Cloud Function cold starts
- **Fix dev-ui locator bug**: `getByText('initial_deal')` matched 2 elements, now uses `.first()`
- **Production suite**: 4 core tests (happy-path, card-placement, observer, leave-game) that cover the critical user paths

## Test plan
- [ ] CI passes (lint + build + unit tests)
- [ ] After merge, deploy workflow smoke tests pass against production
- [ ] Local `npm test` still runs all 7 core tests (bot excluded, stress included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)