### PR TITLE
Add mobile vertical UI as separate view from desktop

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,9 +2,11 @@ import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from './hooks/useAuth.ts';
 import { useGameState } from './hooks/useGameState.ts';
 import { usePlayerHand } from './hooks/usePlayerHand.ts';
+import { useIsMobile } from './hooks/useIsMobile.ts';
 import { RoomSelector } from './components/RoomSelector.tsx';
 import { Lobby } from './components/Lobby.tsx';
 import { GamePage } from './components/GamePage.tsx';
+import { MobileGamePage } from './components/mobile/MobileGamePage.tsx';
 import { GamePhase } from '@shared/core/types';
 
 function getRoomFromUrl(): string | null {
@@ -27,6 +29,7 @@ function App() {
   const [roomId, setRoomId] = useState<string | null>(getRoomFromUrl);
   const { gameState, loading: gameLoading } = useGameState(roomId);
   const hand = usePlayerHand(user?.uid, roomId);
+  const isMobile = useIsMobile();
 
   // Sync URL on popstate (back/forward)
   useEffect(() => {
@@ -86,6 +89,18 @@ function App() {
         signIn={signIn}
         gameState={gameState}
         isInGame={!!isInGame}
+        roomId={roomId}
+        onLeaveRoom={handleLeaveRoom}
+      />
+    );
+  }
+
+  if (isMobile) {
+    return (
+      <MobileGamePage
+        gameState={gameState}
+        hand={hand}
+        uid={user.uid}
         roomId={roomId}
         onLeaveRoom={handleLeaveRoom}
       />

--- a/frontend/src/components/CardComponent.tsx
+++ b/frontend/src/components/CardComponent.tsx
@@ -30,15 +30,17 @@ const SUIT_SELECTED_RING: Record<string, string> = {
   c: 'ring-green-300',
 };
 
-export type CardSize = 'sm' | 'md' | 'lg';
+export type CardSize = 'xs' | 'sm' | 'md' | 'lg';
 
 const SIZE_CLASSES: Record<CardSize, string> = {
+  xs: 'w-6 h-8 text-[7px] rounded-sm',
   sm: 'w-8 h-11 text-[10px] rounded',
   md: 'w-10 h-14 text-xs rounded-md',
   lg: 'w-14 h-20 text-sm rounded-lg',
 };
 
 const RANK_SIZE: Record<CardSize, string> = {
+  xs: 'text-[8px] leading-none',
   sm: 'text-xs leading-none',
   md: 'text-sm leading-none',
   lg: 'text-lg leading-none',

--- a/frontend/src/components/PlayerBoard.tsx
+++ b/frontend/src/components/PlayerBoard.tsx
@@ -5,12 +5,14 @@ import { CardComponent } from './CardComponent.tsx';
 import type { CardSize } from './CardComponent.tsx';
 
 const SPACER_W: Record<CardSize, string> = {
+  xs: 'w-6',
   sm: 'w-8',
   md: 'w-10',
   lg: 'w-14',
 };
 
 const EMPTY_SLOT: Record<CardSize, string> = {
+  xs: 'w-6 h-8 rounded-sm',
   sm: 'w-8 h-11 rounded',
   md: 'w-10 h-14 rounded-md',
   lg: 'w-14 h-20 rounded-lg',

--- a/frontend/src/components/mobile/MobileGamePage.tsx
+++ b/frontend/src/components/mobile/MobileGamePage.tsx
@@ -1,0 +1,248 @@
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import type { GameState, Card, Row, Board } from '@shared/core/types';
+import { GamePhase } from '@shared/core/types';
+import { functions } from '../../firebase.ts';
+import { PlayerBoard } from '../PlayerBoard.tsx';
+import { useCountdown } from '../../hooks/useCountdown.ts';
+import { MobileOpponentGrid } from './MobileOpponentGrid.tsx';
+import { MobileHandArea } from './MobileHandArea.tsx';
+import { MobileRoundOverlay } from './MobileRoundOverlay.tsx';
+import { MobileMatchOverlay } from './MobileMatchOverlay.tsx';
+
+function cardKey(c: Card): string {
+  return `${c.rank}-${c.suit}`;
+}
+
+interface Placement {
+  card: Card;
+  row: Row;
+}
+
+interface MobileGamePageProps {
+  gameState: GameState;
+  hand: Card[];
+  uid: string;
+  roomId: string;
+  onLeaveRoom: () => void;
+}
+
+export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: MobileGamePageProps) {
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [placements, setPlacements] = useState<Placement[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  // Auto-dismiss toast
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 3000);
+    return () => clearTimeout(t);
+  }, [toast]);
+
+  const countdown = useCountdown(gameState.phaseDeadline);
+  const showTimer = (
+    gameState.phase === GamePhase.InitialDeal ||
+    gameState.phase === GamePhase.Street2 ||
+    gameState.phase === GamePhase.Street3 ||
+    gameState.phase === GamePhase.Street4 ||
+    gameState.phase === GamePhase.Street5
+  );
+
+  const isRoundComplete = gameState.phase === GamePhase.Complete;
+  const isMatchComplete = gameState.phase === GamePhase.MatchComplete;
+
+  const isInitialDeal = gameState.phase === GamePhase.InitialDeal;
+  const isStreet = !isInitialDeal && gameState.phase !== GamePhase.Lobby &&
+    gameState.phase !== GamePhase.Scoring && gameState.phase !== GamePhase.Complete &&
+    gameState.phase !== GamePhase.MatchComplete;
+  const requiredPlacements = isInitialDeal ? 5 : 2;
+
+  // Show round results as full-screen takeover — auto-shows when round completes,
+  // auto-hides when phase changes away from Complete (no dismiss button)
+  const showRoundOverlay = isRoundComplete && !isMatchComplete;
+
+  // Reset placement state when phase changes
+  const [prevPhase, setPrevPhase] = useState(gameState.phase);
+  if (prevPhase !== gameState.phase) {
+    setPrevPhase(gameState.phase);
+    setPlacements([]);
+    setSelectedIndex(null);
+    setSubmitting(false);
+  }
+
+  const placedCardKeys = new Set(placements.map((p) => cardKey(p.card)));
+  const remainingHand = hand.filter((c) => !placedCardKeys.has(cardKey(c)));
+
+  const mergedBoard = useMemo((): Board => {
+    const player = gameState.players[uid];
+    if (!player) return { top: [], middle: [], bottom: [] };
+    const board: Board = {
+      top: [...player.board.top],
+      middle: [...player.board.middle],
+      bottom: [...player.board.bottom],
+    };
+    for (const p of placements) {
+      const alreadyOnBoard = board[p.row].some(
+        (c) => c.rank === p.card.rank && c.suit === p.card.suit
+      );
+      if (!alreadyOnBoard) {
+        board[p.row] = [...board[p.row], p.card];
+      }
+    }
+    return board;
+  }, [gameState.players, uid, placements]);
+
+  const handleRowClick = useCallback(async (row: Row) => {
+    if (selectedIndex === null || submitting) return;
+    const card = remainingHand[selectedIndex];
+    if (!card) return;
+
+    const currentRowSize = mergedBoard[row].length;
+    const maxSize = row === 'top' ? 3 : 5;
+    if (currentRowSize >= maxSize) return;
+
+    const newPlacements = [...placements, { card, row }];
+    setPlacements(newPlacements);
+    setSelectedIndex(null);
+
+    if (newPlacements.length === requiredPlacements) {
+      setSubmitting(true);
+      try {
+        const placementData = newPlacements.map((p) => ({
+          card: p.card,
+          row: p.row,
+        }));
+
+        const newPlacedKeys = new Set(newPlacements.map((p) => cardKey(p.card)));
+        const discard = isStreet
+          ? hand.find((c) => !newPlacedKeys.has(cardKey(c))) ?? null
+          : null;
+
+        const placeCardsFn = httpsCallable(functions, 'placeCards');
+        await placeCardsFn({ roomId, placements: placementData, discard });
+      } catch (err) {
+        console.error('Failed to place cards:', err);
+        setToast('Failed to place cards');
+        setPlacements([]);
+        setSubmitting(false);
+      }
+    }
+  }, [selectedIndex, remainingHand, mergedBoard, placements, submitting, requiredPlacements, isStreet, hand, roomId]);
+
+  const handleLeave = useCallback(async () => {
+    setLeaving(true);
+    try {
+      const leaveGameFn = httpsCallable(functions, 'leaveGame');
+      await leaveGameFn({ roomId });
+      onLeaveRoom();
+    } catch (err) {
+      console.error('Failed to leave:', err);
+      setToast('Failed to leave game');
+      setLeaving(false);
+    }
+  }, [roomId, onLeaveRoom]);
+
+  const isObserver = !gameState.playerOrder.includes(uid);
+  const currentPlayer = gameState.players[uid];
+  const expectedCards = gameState.street === 1 ? 5 : 3 + 2 * gameState.street;
+
+  return (
+    <div className="h-[100dvh] bg-gray-900 text-white font-mono flex flex-col overflow-hidden">
+      {/* Compact mobile header */}
+      <div className="border-b border-gray-700 px-2 py-1.5 flex items-center justify-between text-[10px] flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="text-green-400 font-bold tracking-wider">{roomId}</span>
+          {showTimer && (
+            <span className={`font-bold ${countdown < 10 ? 'text-red-400' : 'text-yellow-400'}`}>
+              {countdown}s
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-gray-500">
+            R{gameState.round}/{gameState.totalRounds} S{gameState.street}
+          </span>
+          <button
+            onClick={handleLeave}
+            disabled={leaving}
+            className="px-2 py-1 bg-red-800 active:bg-red-700 disabled:bg-gray-700 text-white text-[10px] rounded"
+          >
+            {leaving ? '...' : 'Leave'}
+          </button>
+        </div>
+      </div>
+
+      {/* Observer banner */}
+      {isObserver && (
+        <div className="bg-blue-900/80 border-b border-blue-700 px-2 py-0.5 text-center text-[10px] text-blue-300 flex-shrink-0">
+          Observing — join next match
+        </div>
+      )}
+
+      {/* Main content: opponents top, player board middle, hand bottom */}
+      <div className="flex-1 flex flex-col min-h-0">
+        {/* Top section: opponent grid */}
+        <div className="flex-shrink-0 border-b border-gray-800" style={{ maxHeight: '35%' }}>
+          <MobileOpponentGrid gameState={gameState} currentUid={uid} />
+        </div>
+
+        {/* Middle section: player's board */}
+        <div className="flex-1 min-h-0 overflow-auto flex items-center justify-center p-2">
+          {currentPlayer && (
+            <PlayerBoard
+              board={mergedBoard}
+              playerName={`${currentPlayer.displayName} (You)`}
+              fouled={currentPlayer.fouled}
+              isCurrentPlayer
+              onRowClick={selectedIndex !== null && !submitting ? handleRowClick : undefined}
+              hasCardSelected={selectedIndex !== null && !submitting}
+              cardSize="sm"
+              score={currentPlayer.score}
+              hasPlaced={(() => {
+                const b = mergedBoard;
+                return b.top.length + b.middle.length + b.bottom.length >= expectedCards;
+              })()}
+            />
+          )}
+        </div>
+
+        {/* Bottom section: hand area */}
+        <MobileHandArea
+          hand={hand}
+          gameState={gameState}
+          uid={uid}
+          selectedIndex={selectedIndex}
+          onSelectCard={setSelectedIndex}
+          placements={placements}
+          submitting={submitting}
+        />
+      </div>
+
+      {/* Full-screen round results overlay (auto-dismiss, no close button) */}
+      {showRoundOverlay && (
+        <MobileRoundOverlay
+          gameState={gameState}
+          currentUid={uid}
+        />
+      )}
+
+      {/* Full-screen match results overlay */}
+      {isMatchComplete && (
+        <MobileMatchOverlay
+          gameState={gameState}
+          currentUid={uid}
+          roomId={roomId}
+        />
+      )}
+
+      {/* Toast */}
+      {toast && (
+        <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-red-900 border border-red-700 px-3 py-1.5 text-[10px] text-red-300 shadow-lg z-50 rounded">
+          {toast}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/mobile/MobileHandArea.tsx
+++ b/frontend/src/components/mobile/MobileHandArea.tsx
@@ -1,0 +1,97 @@
+import { useCallback } from 'react';
+import type { Card, GameState } from '@shared/core/types';
+import { GamePhase } from '@shared/core/types';
+import { CardComponent } from '../CardComponent.tsx';
+import type { Placement } from '../GamePage.tsx';
+
+function cardKey(c: Card): string {
+  return `${c.rank}-${c.suit}`;
+}
+
+interface MobileHandAreaProps {
+  hand: Card[];
+  gameState: GameState;
+  uid: string;
+  selectedIndex: number | null;
+  onSelectCard: (index: number | null) => void;
+  placements: Placement[];
+  submitting: boolean;
+}
+
+export function MobileHandArea({
+  hand, gameState, uid, selectedIndex, onSelectCard,
+  placements, submitting,
+}: MobileHandAreaProps) {
+  const isInitialDeal = gameState.phase === GamePhase.InitialDeal;
+  const requiredPlacements = isInitialDeal ? 5 : 2;
+  const placedCardKeys = new Set(placements.map((p) => cardKey(p.card)));
+  const remainingHand = hand.filter((c) => !placedCardKeys.has(cardKey(c)));
+
+  const player = gameState.players[uid];
+  const alreadyPlaced = player
+    ? player.board.top.length + player.board.middle.length + player.board.bottom.length
+    : 0;
+  const waitingForOthers = isInitialDeal
+    ? alreadyPlaced >= 5 && hand.length === 0
+    : alreadyPlaced > 0 && hand.length === 0;
+
+  const handleCardClick = useCallback((index: number) => {
+    if (submitting) return;
+    onSelectCard(selectedIndex === index ? null : index);
+  }, [selectedIndex, submitting, onSelectCard]);
+
+  const allPlaced = placements.length >= requiredPlacements;
+
+  let statusMessage: string | null = null;
+  let showCards = false;
+
+  if (gameState.phase === GamePhase.Lobby) {
+    statusMessage = gameState.round === 0 ? 'Waiting for host...' : 'Next round starting...';
+  } else if (hand.length === 0 && !waitingForOthers) {
+    statusMessage = null;
+  } else if (waitingForOthers || submitting) {
+    statusMessage = submitting ? 'Submitting...' : 'Waiting for others...';
+  } else {
+    showCards = true;
+  }
+
+  return (
+    <div className="bg-gray-900/90 border-t border-gray-700 px-2 py-2 flex-shrink-0">
+      {/* Card area - large touch targets */}
+      <div className="min-h-[4.5rem] flex items-center justify-center">
+        {showCards && !allPlaced ? (
+          <div className="flex justify-center gap-3">
+            {remainingHand.map((card, i) => (
+              <div key={cardKey(card)} data-testid={`mobile-hand-card-${i}`}>
+                <CardComponent
+                  card={card}
+                  size="lg"
+                  selected={selectedIndex === i}
+                  onClick={() => handleCardClick(i)}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <span className="text-gray-400 text-xs">
+            {statusMessage ?? '\u00a0'}
+          </span>
+        )}
+      </div>
+
+      {/* Instruction line */}
+      {showCards && !allPlaced && (
+        <div className="text-[10px] text-gray-500 text-center mt-1">
+          {selectedIndex !== null
+            ? 'Tap a row to place'
+            : 'Tap a card to select'}
+          {placements.length > 0 && (
+            <span className="ml-1 text-gray-600">
+              ({placements.length}/{requiredPlacements})
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/mobile/MobileMatchOverlay.tsx
+++ b/frontend/src/components/mobile/MobileMatchOverlay.tsx
@@ -1,0 +1,163 @@
+import { useState, useCallback } from 'react';
+import { httpsCallable } from 'firebase/functions';
+import type { GameState } from '@shared/core/types';
+import { scorePairwise } from '@shared/game-logic/scoring';
+import { functions } from '../../firebase.ts';
+
+interface MobileMatchOverlayProps {
+  gameState: GameState;
+  currentUid: string;
+  roomId: string;
+}
+
+function formatScore(n: number): string {
+  return n >= 0 ? `+${n}` : `${n}`;
+}
+
+function pairwiseLabel(rowPoints: number, scoopBonus: number, total: number, aFouled: boolean, bFouled: boolean): string {
+  if (aFouled && bFouled) return `both fouled = ${formatScore(total)}`;
+  if (aFouled || bFouled) return `foul = ${formatScore(total)}`;
+  if (scoopBonus !== 0) return `rows ${formatScore(rowPoints)} scoop ${formatScore(scoopBonus)} = ${formatScore(total)}`;
+  return `rows ${formatScore(rowPoints)} = ${formatScore(total)}`;
+}
+
+export function MobileMatchOverlay({ gameState, currentUid, roomId }: MobileMatchOverlayProps) {
+  const [restarting, setRestarting] = useState(false);
+  const isHost = gameState.hostUid === currentUid;
+
+  const standings = gameState.playerOrder
+    .map((uid) => gameState.players[uid])
+    .filter(Boolean)
+    .sort((a, b) => b.score - a.score);
+
+  const roundResults = gameState.roundResults ?? {};
+  const activePlayers = gameState.playerOrder
+    .map((uid) => gameState.players[uid])
+    .filter(Boolean);
+
+  const handlePlayAgain = useCallback(async () => {
+    setRestarting(true);
+    try {
+      const playAgainFn = httpsCallable(functions, 'playAgain');
+      await playAgainFn({ roomId });
+    } catch (err) {
+      console.error('Failed to restart:', err);
+      setRestarting(false);
+    }
+  }, [roomId]);
+
+  return (
+    <div data-testid="mobile-match-overlay" className="fixed inset-0 bg-gray-900 z-50 flex flex-col items-center justify-center px-6 font-mono overflow-y-auto">
+      <div className="py-8 w-full max-w-sm">
+        <h2 className="text-xl font-bold text-white mb-6 text-center">Match Complete</h2>
+
+        {/* Final round breakdown */}
+        {Object.keys(roundResults).length > 0 && (
+          <div className="mb-6">
+            <h3 className="text-xs font-bold text-gray-400 mb-2">Final Round</h3>
+            <table className="w-full text-sm mb-3">
+              <thead>
+                <tr className="text-gray-500 border-b border-gray-700">
+                  <th className="text-left py-2">Player</th>
+                  <th className="text-right py-2">Round</th>
+                </tr>
+              </thead>
+              <tbody>
+                {activePlayers.map((player) => {
+                  const result = roundResults[player.uid];
+                  const roundScore = result?.netScore ?? 0;
+                  return (
+                    <tr
+                      key={player.uid}
+                      className={`border-b border-gray-800 ${
+                        player.uid === currentUid ? 'text-yellow-300' : 'text-gray-300'
+                      }`}
+                    >
+                      <td className="py-2">
+                        {player.displayName}
+                        {player.uid === currentUid && ' (you)'}
+                        {result?.fouled && (
+                          <span className="ml-1 text-red-400 text-xs">[FOULED]</span>
+                        )}
+                      </td>
+                      <td className="py-2 text-right">{formatScore(roundScore)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+
+            {activePlayers.length >= 2 && (
+              <div className="text-xs text-gray-500 border-t border-gray-800 pt-2 mb-4">
+                <div className="font-bold text-gray-400 mb-1">Pairwise</div>
+                {activePlayers.map((pA, i) =>
+                  activePlayers.slice(i + 1).map((pB) => {
+                    const aFouled = roundResults[pA.uid]?.fouled ?? false;
+                    const bFouled = roundResults[pB.uid]?.fouled ?? false;
+                    const result = scorePairwise(
+                      pA.uid, aFouled, pA.board,
+                      pB.uid, bFouled, pB.board,
+                    );
+                    return (
+                      <div key={`${pA.uid}-${pB.uid}`} className="flex justify-between gap-2 mb-1">
+                        <span className="text-gray-400 truncate">{pA.displayName} vs {pB.displayName}</span>
+                        <span className="whitespace-nowrap">
+                          {pairwiseLabel(result.rowPoints, result.scoopBonus, result.total, aFouled, bFouled)}
+                        </span>
+                      </div>
+                    );
+                  })
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Final standings */}
+        <h3 className="text-xs font-bold text-gray-400 mb-2">Final Standings</h3>
+        <table className="w-full text-sm mb-6">
+          <thead>
+            <tr className="text-gray-500 border-b border-gray-700">
+              <th className="text-left py-2">#</th>
+              <th className="text-left py-2">Player</th>
+              <th className="text-right py-2">Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {standings.map((player, i) => (
+              <tr
+                key={player.uid}
+                className={`border-b border-gray-800 ${
+                  player.uid === currentUid ? 'text-yellow-300' : 'text-gray-300'
+                }`}
+              >
+                <td className="py-2">{i + 1}</td>
+                <td className="py-2">
+                  {player.displayName}
+                  {player.uid === currentUid && ' (you)'}
+                </td>
+                <td className="py-2 text-right">{formatScore(player.score)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        {/* Host action */}
+        <div className="flex justify-center">
+          {isHost ? (
+            <button
+              data-testid="play-again-button"
+              onClick={handlePlayAgain}
+              disabled={restarting}
+              className="px-8 py-3 bg-green-700 hover:bg-green-600 active:bg-green-800 disabled:bg-gray-700 text-white text-sm font-bold rounded-lg"
+            >
+              {restarting ? '...' : 'Play Again'}
+            </button>
+          ) : (
+            <span className="text-sm text-gray-500">Waiting for host...</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/mobile/MobileOpponentGrid.tsx
+++ b/frontend/src/components/mobile/MobileOpponentGrid.tsx
@@ -1,0 +1,64 @@
+import type { GameState } from '@shared/core/types';
+import { PlayerBoard } from '../PlayerBoard.tsx';
+
+interface MobileOpponentGridProps {
+  gameState: GameState;
+  currentUid: string;
+}
+
+export function MobileOpponentGrid({ gameState, currentUid }: MobileOpponentGridProps) {
+  const otherPlayers = gameState.playerOrder.filter((uid) => uid !== currentUid);
+  const expectedCards = gameState.street === 1 ? 5 : 3 + 2 * gameState.street;
+
+  const observers = Object.values(gameState.players).filter(
+    (p) => !gameState.playerOrder.includes(p.uid)
+  );
+
+  if (otherPlayers.length === 0 && observers.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-gray-500 text-xs">
+        Waiting for opponents...
+      </div>
+    );
+  }
+
+  // 3-column grid, centered when fewer than 3
+  const gridCols = otherPlayers.length === 1
+    ? 'flex justify-center'
+    : otherPlayers.length === 2
+    ? 'grid grid-cols-2 gap-1'
+    : 'grid grid-cols-3 gap-1';
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex-1 overflow-y-auto overflow-x-hidden p-1">
+        <div className={gridCols}>
+          {otherPlayers.map((uid) => {
+            const player = gameState.players[uid];
+            if (!player) return null;
+            const boardCount = player.board.top.length + player.board.middle.length + player.board.bottom.length;
+            return (
+              <div key={uid} className={otherPlayers.length === 1 ? 'w-40' : ''}>
+                <PlayerBoard
+                  board={player.board}
+                  playerName={player.displayName}
+                  fouled={player.fouled}
+                  cardSize="xs"
+                  score={player.score}
+                  hasPlaced={boardCount >= expectedCards}
+                  disconnected={player.disconnected}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {observers.length > 0 && (
+        <div className="text-[10px] text-gray-500 text-center py-0.5 border-t border-gray-800">
+          Watching: {observers.map((p) => p.displayName).join(', ')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/mobile/MobileRoundOverlay.tsx
+++ b/frontend/src/components/mobile/MobileRoundOverlay.tsx
@@ -1,0 +1,95 @@
+import type { GameState } from '@shared/core/types';
+import { scorePairwise } from '@shared/game-logic/scoring';
+
+interface MobileRoundOverlayProps {
+  gameState: GameState;
+  currentUid: string;
+}
+
+function formatScore(n: number): string {
+  return n >= 0 ? `+${n}` : `${n}`;
+}
+
+function pairwiseLabel(rowPoints: number, scoopBonus: number, total: number, aFouled: boolean, bFouled: boolean): string {
+  if (aFouled && bFouled) return `both fouled = ${formatScore(total)}`;
+  if (aFouled || bFouled) return `foul = ${formatScore(total)}`;
+  if (scoopBonus !== 0) return `rows ${formatScore(rowPoints)} scoop ${formatScore(scoopBonus)} = ${formatScore(total)}`;
+  return `rows ${formatScore(rowPoints)} = ${formatScore(total)}`;
+}
+
+export function MobileRoundOverlay({ gameState, currentUid }: MobileRoundOverlayProps) {
+  const players = gameState.playerOrder.map((uid) => gameState.players[uid]).filter(Boolean);
+  const roundResults = gameState.roundResults ?? {};
+
+  return (
+    <div data-testid="mobile-round-overlay" className="fixed inset-0 bg-gray-900 z-50 flex flex-col items-center justify-center px-6 font-mono">
+      <h2 className="text-lg font-bold text-white mb-6">
+        Round {gameState.round}/{gameState.totalRounds}
+      </h2>
+
+      {/* Score table */}
+      <div className="w-full max-w-sm mb-6">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-gray-500 border-b border-gray-700">
+              <th className="text-left py-2">Player</th>
+              <th className="text-right py-2">Round</th>
+              <th className="text-right py-2">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {players.map((player) => {
+              const result = roundResults[player.uid];
+              const roundScore = result?.netScore ?? 0;
+              return (
+                <tr
+                  key={player.uid}
+                  className={`border-b border-gray-800 ${
+                    player.uid === currentUid ? 'text-yellow-300' : 'text-gray-300'
+                  }`}
+                >
+                  <td className="py-2">
+                    {player.displayName}
+                    {player.uid === currentUid && ' (you)'}
+                    {result?.fouled && (
+                      <span className="ml-1 text-red-400 text-xs">[FOULED]</span>
+                    )}
+                  </td>
+                  <td className="py-2 text-right">{formatScore(roundScore)}</td>
+                  <td className="py-2 text-right">{formatScore(player.score)}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pairwise breakdown */}
+      {players.length >= 2 && (
+        <div className="w-full max-w-sm text-xs text-gray-500 border-t border-gray-800 pt-3 mb-6">
+          <div className="font-bold text-gray-400 mb-2">Pairwise</div>
+          {players.map((pA, i) =>
+            players.slice(i + 1).map((pB) => {
+              const aFouled = roundResults[pA.uid]?.fouled ?? false;
+              const bFouled = roundResults[pB.uid]?.fouled ?? false;
+              const result = scorePairwise(
+                pA.uid, aFouled, pA.board,
+                pB.uid, bFouled, pB.board,
+              );
+              return (
+                <div key={`${pA.uid}-${pB.uid}`} className="flex justify-between gap-2 mb-1">
+                  <span className="text-gray-400 truncate">{pA.displayName} vs {pB.displayName}</span>
+                  <span className="whitespace-nowrap">
+                    {pairwiseLabel(result.rowPoints, result.scoopBonus, result.total, aFouled, bFouled)}
+                  </span>
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+
+      <p className="text-xs text-gray-500 animate-pulse">Next round starting...</p>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useIsMobile.ts
+++ b/frontend/src/hooks/useIsMobile.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => window.innerWidth < MOBILE_BREAKPOINT
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
Adds a complete mobile game view optimized for vertical phone orientation
and thumb interaction. The mobile/desktop switch is a hardcoded if-statement
in App.tsx based on viewport width (<768px).

Mobile-specific components:
- MobileGamePage: main layout with compact header, opponent grid, player
  board, and hand area using 100dvh for proper mobile viewport
- MobileOpponentGrid: 3x1 scrollable grid (centered for <3 opponents)
- MobileHandArea: large touch-target cards at bottom of screen
- MobileRoundOverlay: full-screen takeover for round results, no dismiss
  button, auto-closes when next round starts
- MobileMatchOverlay: full-screen takeover for match end, host gets
  Play Again button

Also adds 'xs' card size (w-6 h-8) to CardComponent and PlayerBoard for
compact opponent boards on mobile.

https://claude.ai/code/session_011eDfndGZxh2rTLwd79CPEj