### PR TITLE
Add Zod schemas for Firestore runtime validation, eliminate type assertion casts

### DIFF
--- a/dealer/package.json
+++ b/dealer/package.json
@@ -14,7 +14,8 @@
     "node": "22"
   },
   "dependencies": {
-    "firebase-admin": "^13.0.0"
+    "firebase-admin": "^13.0.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "tsx": "^4.21.0",

--- a/dealer/src/dealer.test.ts
+++ b/dealer/src/dealer.test.ts
@@ -64,6 +64,19 @@ function createMockFirestore() {
 
 // ---- Helpers ----
 
+function makePlayer(uid: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    uid,
+    displayName: uid,
+    board: { top: [], middle: [], bottom: [] },
+    currentHand: [],
+    disconnected: false,
+    fouled: false,
+    score: 0,
+    ...overrides,
+  };
+}
+
 function gameState(overrides: Partial<{
   phase: string;
   street: number;
@@ -72,8 +85,10 @@ function gameState(overrides: Partial<{
   playerOrder: string[];
   players: Record<string, unknown>;
   phaseDeadline: number | null;
+  hostUid: string;
 }> = {}): Record<string, unknown> {
   return {
+    gameId: 'TEST',
     phase: 'lobby',
     street: 0,
     round: 0,
@@ -81,6 +96,9 @@ function gameState(overrides: Partial<{
     playerOrder: [],
     players: {},
     phaseDeadline: null,
+    hostUid: 'p1',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
     ...overrides,
   };
 }
@@ -99,8 +117,8 @@ function placementPhaseState(opts: {
     round: 1,
     playerOrder: ['p1', 'p2'],
     players: {
-      p1: { uid: 'p1', currentHand: hand, fouled: false, board: { top: [], middle: [], bottom: [] } },
-      p2: { uid: 'p2', currentHand: [], fouled: false, board: { top: [], middle: [], bottom: [] } },
+      p1: makePlayer('p1', { currentHand: hand }),
+      p2: makePlayer('p2'),
     },
     phaseDeadline: deadline,
   });

--- a/dealer/src/dealer.ts
+++ b/dealer/src/dealer.ts
@@ -1,5 +1,7 @@
 import type { Firestore } from 'firebase-admin/firestore';
+import type { GameState } from '../../shared/core/types';
 import { GamePhase as GP } from '../../shared/core/types';
+import { parseGameState } from '../../shared/core/schemas';
 import {
   maybeStartRound,
   scoreRound,
@@ -81,14 +83,11 @@ export class Dealer {
   }
 
   private onGameSnapshot(roomId: string, doc: FirebaseFirestore.QueryDocumentSnapshot): void {
-    const game = doc.data();
-    const phase = game.phase as string;
-    const phaseDeadline = (game.phaseDeadline as number | null) ?? null;
-    const playerOrder = game.playerOrder as string[];
+    const game = parseGameState(doc.data());
 
-    console.log(`[Dealer] [${roomId}] Snapshot: phase=${phase}, street=${game.street}, players=${playerOrder.length}`);
+    console.log(`[Dealer] [${roomId}] Snapshot: phase=${game.phase}, street=${game.street}, players=${game.playerOrder.length}`);
 
-    this.maybeUpdateTimer(roomId, phaseDeadline, phase);
+    this.maybeUpdateTimer(roomId, game.phaseDeadline, game.phase);
 
     this.reactToPhase(roomId, game).catch((err) => {
       console.error(`[Dealer] [${roomId}] Error reacting to phase:`, err);
@@ -128,41 +127,33 @@ export class Dealer {
     }
   }
 
-  private async reactToPhase(roomId: string, game: Record<string, unknown>): Promise<void> {
-    const phase = game.phase as string;
-    const playerOrder = game.playerOrder as string[];
-
-    if (phase === GP.Lobby) {
-      const round = game.round as number;
-      if (round >= 1 && playerOrder.length >= 2) {
+  private async reactToPhase(roomId: string, game: GameState): Promise<void> {
+    if (game.phase === GP.Lobby) {
+      if (game.round >= 1 && game.playerOrder.length >= 2) {
         console.log(`[Dealer] [${roomId}] Lobby with round >= 1 and 2+ players — starting round`);
         await maybeStartRound(this.db, roomId);
       }
       return;
     }
 
-    if (phase === GP.MatchComplete) {
+    if (game.phase === GP.MatchComplete) {
       // Wait for host to click "Play Again"
       return;
     }
 
-    if (isPlacementPhase(phase)) {
-      const players = game.players as Record<
-        string,
-        { currentHand: { length: number }; fouled: boolean }
-      >;
-      const allPlaced = playerOrder.every((uid) => {
-        const p = players[uid];
+    if (isPlacementPhase(game.phase)) {
+      const allPlaced = game.playerOrder.every((uid) => {
+        const p = game.players[uid];
         return !p || p.fouled || p.currentHand.length === 0;
       });
       if (allPlaced) {
-        console.log(`[Dealer] [${roomId}] All placed in ${phase} — advancing`);
+        console.log(`[Dealer] [${roomId}] All placed in ${game.phase} — advancing`);
         await checkAndAdvance(this.db, roomId);
       }
       return;
     }
 
-    if (phase === GP.Scoring) {
+    if (game.phase === GP.Scoring) {
       console.log(`[Dealer] [${roomId}] Scoring round`);
       await scoreRound(this.db, roomId);
       return;

--- a/dealer/src/game-engine-guards.test.ts
+++ b/dealer/src/game-engine-guards.test.ts
@@ -8,10 +8,11 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import * as admin from 'firebase-admin';
 import type { Firestore } from 'firebase-admin/firestore';
+import type { Card, PlayerState, GameState } from '../../shared/core/types';
 import { GamePhase as GP } from '../../shared/core/types';
-import type { Card } from '../../shared/core/types';
 import { gameDoc, handDoc } from '../../shared/core/firestore-paths';
 import { emptyBoard } from '../../shared/game-logic/board-utils';
+import { parseGameState } from '../../shared/core/schemas';
 import { handlePhaseTimeout } from './game-engine';
 import { advanceStreet } from './game-engine';
 
@@ -43,21 +44,39 @@ function makeHand(n: number): Card[] {
   }));
 }
 
-async function setGameState(roomId: string, state: Record<string, unknown>) {
+function makePlayer(uid: string, overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    uid,
+    displayName: uid,
+    board: emptyBoard(),
+    currentHand: [],
+    disconnected: false,
+    fouled: false,
+    score: 0,
+    ...overrides,
+  };
+}
+
+async function setGameState(roomId: string, state: Partial<GameState>) {
   await db.doc(gameDoc(roomId)).set({
+    gameId: roomId,
     phase: GP.Lobby,
     street: 0,
+    round: 1,
+    totalRounds: 3,
+    hostUid: 'p1',
     playerOrder: [],
     players: {},
     phaseDeadline: null,
+    createdAt: Date.now(),
     updatedAt: Date.now(),
     ...state,
   });
 }
 
-async function getGame(roomId: string) {
+async function getGame(roomId: string): Promise<GameState> {
   const snap = await db.doc(gameDoc(roomId)).get();
-  return snap.data()!;
+  return parseGameState(snap.data());
 }
 
 // ---- handlePhaseTimeout guards ----
@@ -70,8 +89,8 @@ describe('handlePhaseTimeout guards', () => {
       street: 5,
       playerOrder: ['p1', 'p2'],
       players: {
-        p1: { uid: 'p1', currentHand: makeHand(3), fouled: false, board: emptyBoard() },
-        p2: { uid: 'p2', currentHand: makeHand(3), fouled: false, board: emptyBoard() },
+        p1: makePlayer('p1', { currentHand: makeHand(3) }),
+        p2: makePlayer('p2', { currentHand: makeHand(3) }),
       },
       phaseDeadline: Date.now() - 1000, // expired
     });
@@ -80,8 +99,8 @@ describe('handlePhaseTimeout guards', () => {
     const game = await getGame(roomId);
 
     // Players should NOT be fouled — wrong phase
-    expect((game.players as Record<string, { fouled: boolean }>).p1.fouled).toBe(false);
-    expect((game.players as Record<string, { fouled: boolean }>).p2.fouled).toBe(false);
+    expect(game.players.p1.fouled).toBe(false);
+    expect(game.players.p2.fouled).toBe(false);
   });
 
   it('does nothing when phase is complete', async () => {
@@ -91,7 +110,7 @@ describe('handlePhaseTimeout guards', () => {
       street: 5,
       playerOrder: ['p1'],
       players: {
-        p1: { uid: 'p1', currentHand: makeHand(3), fouled: false, board: emptyBoard() },
+        p1: makePlayer('p1', { currentHand: makeHand(3) }),
       },
       phaseDeadline: Date.now() - 1000,
     });
@@ -99,7 +118,7 @@ describe('handlePhaseTimeout guards', () => {
     await handlePhaseTimeout(db, roomId);
     const game = await getGame(roomId);
 
-    expect((game.players as Record<string, { fouled: boolean }>).p1.fouled).toBe(false);
+    expect(game.players.p1.fouled).toBe(false);
   });
 
   it('does nothing when deadline has not expired', async () => {
@@ -109,8 +128,8 @@ describe('handlePhaseTimeout guards', () => {
       street: 1,
       playerOrder: ['p1', 'p2'],
       players: {
-        p1: { uid: 'p1', currentHand: makeHand(5), fouled: false, board: emptyBoard() },
-        p2: { uid: 'p2', currentHand: [], fouled: false, board: emptyBoard() },
+        p1: makePlayer('p1', { currentHand: makeHand(5) }),
+        p2: makePlayer('p2'),
       },
       phaseDeadline: Date.now() + 30_000, // 30 seconds from now
     });
@@ -122,18 +141,18 @@ describe('handlePhaseTimeout guards', () => {
     const game = await getGame(roomId);
 
     // p1 should NOT be fouled — deadline hasn't passed
-    expect((game.players as Record<string, { fouled: boolean }>).p1.fouled).toBe(false);
+    expect(game.players.p1.fouled).toBe(false);
   });
 
-  it('fouls unplaced players when deadline has expired in placement phase', async () => {
+  it('auto-places cards for unplaced players when deadline has expired', async () => {
     const roomId = uniqueRoomId();
     await setGameState(roomId, {
       phase: GP.InitialDeal,
       street: 1,
       playerOrder: ['p1', 'p2'],
       players: {
-        p1: { uid: 'p1', currentHand: makeHand(5), fouled: false, board: emptyBoard() },
-        p2: { uid: 'p2', currentHand: [], fouled: false, board: emptyBoard() },
+        p1: makePlayer('p1', { currentHand: makeHand(5) }),
+        p2: makePlayer('p2'),
       },
       phaseDeadline: Date.now() - 1000, // expired
     });
@@ -143,11 +162,9 @@ describe('handlePhaseTimeout guards', () => {
     await handlePhaseTimeout(db, roomId);
     const game = await getGame(roomId);
 
-    // p1 fouled (had cards), p2 not fouled (already placed)
-    const players = game.players as Record<string, { fouled: boolean; currentHand: Card[] }>;
-    expect(players.p1.fouled).toBe(true);
-    expect(players.p1.currentHand).toEqual([]);
-    expect(players.p2.fouled).toBe(false);
+    // p1 had cards auto-placed, p2 already placed
+    expect(game.players.p1.currentHand).toEqual([]);
+    expect(game.players.p2.fouled).toBe(false);
     expect(game.phaseDeadline).toBeNull();
   });
 });
@@ -162,7 +179,7 @@ describe('advanceStreet guards', () => {
       street: 5,
       playerOrder: ['p1'],
       players: {
-        p1: { uid: 'p1', currentHand: [], fouled: false, board: emptyBoard() },
+        p1: makePlayer('p1'),
       },
     });
 
@@ -177,7 +194,7 @@ describe('advanceStreet guards', () => {
       street: 5,
       playerOrder: ['p1'],
       players: {
-        p1: { uid: 'p1', currentHand: [], fouled: false, board: emptyBoard() },
+        p1: makePlayer('p1'),
       },
     });
 
@@ -192,8 +209,8 @@ describe('advanceStreet guards', () => {
       street: 0,
       playerOrder: ['p1', 'p2'],
       players: {
-        p1: { uid: 'p1', currentHand: [], fouled: false, board: emptyBoard() },
-        p2: { uid: 'p2', currentHand: [], fouled: false, board: emptyBoard() },
+        p1: makePlayer('p1'),
+        p2: makePlayer('p2'),
       },
     });
 
@@ -208,8 +225,8 @@ describe('advanceStreet guards', () => {
       street: 1,
       playerOrder: ['p1', 'p2'],
       players: {
-        p1: { uid: 'p1', currentHand: makeHand(5), fouled: false, board: emptyBoard() },
-        p2: { uid: 'p2', currentHand: [], fouled: false, board: emptyBoard() },
+        p1: makePlayer('p1', { currentHand: makeHand(5) }),
+        p2: makePlayer('p2'),
       },
     });
 
@@ -224,8 +241,8 @@ describe('advanceStreet guards', () => {
       street: 5,
       playerOrder: ['p1', 'p2'],
       players: {
-        p1: { uid: 'p1', currentHand: [], fouled: false, board: emptyBoard() },
-        p2: { uid: 'p2', currentHand: [], fouled: false, board: emptyBoard() },
+        p1: makePlayer('p1'),
+        p2: makePlayer('p2'),
       },
     });
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "firebase": "^12.9.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "tailwindcss": "^4.1.18"
+    "tailwindcss": "^4.1.18",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/hooks/useGameState.ts
+++ b/frontend/src/hooks/useGameState.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { doc, onSnapshot } from 'firebase/firestore';
 import { db } from '../firebase.ts';
 import type { GameState } from '@shared/core/types';
+import { parseGameState } from '@shared/core/schemas';
 
 export function useGameState(roomId: string | null) {
   const [gameState, setGameState] = useState<GameState | null>(null);
@@ -26,7 +27,7 @@ export function useGameState(roomId: string | null) {
       doc(db, 'games', roomId),
       (snap) => {
         if (snap.exists()) {
-          setGameState(snap.data() as GameState);
+          setGameState(parseGameState(snap.data()));
         } else {
           setGameState(null);
         }

--- a/frontend/src/hooks/usePlayerHand.ts
+++ b/frontend/src/hooks/usePlayerHand.ts
@@ -2,10 +2,7 @@ import { useState, useEffect } from 'react';
 import { doc, onSnapshot } from 'firebase/firestore';
 import { db } from '../firebase.ts';
 import type { Card } from '@shared/core/types';
-
-interface HandDoc {
-  cards: Card[];
-}
+import { parseHandDoc } from '@shared/core/schemas';
 
 export function usePlayerHand(uid: string | undefined, roomId: string | null) {
   const [hand, setHand] = useState<Card[]>([]);
@@ -16,7 +13,7 @@ export function usePlayerHand(uid: string | undefined, roomId: string | null) {
       doc(db, 'games', roomId, 'hands', uid),
       (snap) => {
         if (snap.exists()) {
-          const data = snap.data() as HandDoc;
+          const data = parseHandDoc(snap.data());
           setHand(data.cards ?? []);
         } else {
           setHand([]);

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,8 @@
   },
   "dependencies": {
     "firebase-admin": "^13.0.0",
-    "firebase-functions": "^6.3.0"
+    "firebase-functions": "^6.3.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "typescript": "~5.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
       "name": "pineapple-dealer",
       "version": "0.0.0",
       "dependencies": {
-        "firebase-admin": "^13.0.0"
+        "firebase-admin": "^13.0.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "tsx": "^4.21.0",
@@ -82,7 +83,8 @@
         "firebase": "^12.9.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "tailwindcss": "^4.1.18"
+        "tailwindcss": "^4.1.18",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -104,7 +106,8 @@
       "version": "0.0.0",
       "dependencies": {
         "firebase-admin": "^13.0.0",
-        "firebase-functions": "^6.3.0"
+        "firebase-functions": "^6.3.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "typescript": "~5.7.0"
@@ -7387,7 +7390,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/shared/core/schemas.ts
+++ b/shared/core/schemas.ts
@@ -1,0 +1,123 @@
+/**
+ * Zod schemas for all Firestore documents.
+ *
+ * These schemas serve as the runtime validation layer at the Firestore boundary.
+ * Every piece of data read from Firestore passes through one of these schemas
+ * before entering application code — eliminating the need for `as` casts.
+ *
+ * The parse functions return the existing TypeScript types from types.ts.
+ * The `as` casts inside parse functions are safe: Zod has already validated the
+ * data at runtime, so the shape is guaranteed to match.
+ */
+import { z } from 'zod';
+import type {
+  PlayerState,
+  GameState,
+  RoundResult,
+  HandDoc,
+  DeckDoc,
+} from './types';
+
+// ---- Primitive schemas ----
+
+const SuitSchema = z.enum(['c', 'd', 'h', 's']);
+
+const RankSchema = z.number().int().min(2).max(14);
+
+export const CardSchema = z.object({
+  suit: SuitSchema,
+  rank: RankSchema,
+});
+
+export const BoardSchema = z.object({
+  top: z.array(CardSchema),
+  middle: z.array(CardSchema),
+  bottom: z.array(CardSchema),
+});
+
+// ---- Game phase ----
+
+const GAME_PHASE_VALUES = [
+  'lobby',
+  'initial_deal',
+  'street_2',
+  'street_3',
+  'street_4',
+  'street_5',
+  'scoring',
+  'complete',
+  'match_complete',
+] as const;
+
+const GamePhaseSchema = z.enum(GAME_PHASE_VALUES);
+
+// ---- Player state (what lives inside the game doc players map) ----
+
+export const PlayerStateSchema = z.object({
+  uid: z.string(),
+  displayName: z.string(),
+  board: BoardSchema,
+  currentHand: z.array(CardSchema),
+  disconnected: z.boolean(),
+  fouled: z.boolean(),
+  score: z.number(),
+});
+
+// ---- Round results ----
+
+export const RoundResultSchema = z.object({
+  netScore: z.number(),
+  fouled: z.boolean(),
+});
+
+// ---- Game state (the games/{roomId} document) ----
+
+export const GameStateSchema = z.object({
+  gameId: z.string(),
+  phase: GamePhaseSchema,
+  players: z.record(z.string(), PlayerStateSchema),
+  playerOrder: z.array(z.string()),
+  street: z.number().int(),
+  round: z.number().int(),
+  totalRounds: z.number().int(),
+  hostUid: z.string(),
+  roundResults: z.record(z.string(), RoundResultSchema).optional(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  phaseDeadline: z.number().nullable(),
+});
+
+// ---- Subcollection documents ----
+
+export const HandDocSchema = z.object({
+  cards: z.array(CardSchema),
+});
+
+export const DeckDocSchema = z.object({
+  cards: z.array(CardSchema),
+});
+
+// ---- Parse functions ----
+// Single safe cast point, backed by runtime validation.
+// Zod validates the shape; the cast bridges Zod's inferred type (e.g. rank: number)
+// to the existing narrow TypeScript type (e.g. rank: Rank).
+
+export function parseGameState(data: unknown): GameState {
+  return GameStateSchema.parse(data) as unknown as GameState;
+}
+
+export function parsePlayerState(data: unknown): PlayerState {
+  return PlayerStateSchema.parse(data) as unknown as PlayerState;
+}
+
+export function parseRoundResult(data: unknown): RoundResult {
+  return RoundResultSchema.parse(data) as unknown as RoundResult;
+}
+
+export function parseHandDoc(data: unknown): HandDoc {
+  return HandDocSchema.parse(data) as unknown as HandDoc;
+}
+
+export function parseDeckDoc(data: unknown): DeckDoc {
+  return DeckDocSchema.parse(data) as unknown as DeckDoc;
+}

--- a/shared/core/types.ts
+++ b/shared/core/types.ts
@@ -98,11 +98,20 @@ export interface PlayerState {
   uid: string;
   displayName: string;
   board: Board;
-  deck: Card[];          // remaining cards in this player's personal deck
   currentHand: Card[];   // cards currently in hand (to be placed)
   disconnected: boolean;
   fouled: boolean;
   score: number;
+}
+
+/** Subcollection document: games/{roomId}/hands/{uid} */
+export interface HandDoc {
+  cards: Card[];
+}
+
+/** Subcollection document: games/{roomId}/decks/{uid} */
+export interface DeckDoc {
+  cards: Card[];
 }
 
 export interface RoundResult {

--- a/shared/index.ts
+++ b/shared/index.ts
@@ -2,6 +2,7 @@
 export * from './core/types';
 export * from './core/constants';
 export * from './core/firestore-paths';
+export * from './core/schemas';
 
 // Game logic
 export * from './game-logic/deck';


### PR DESCRIPTION
- Create shared/core/schemas.ts with Zod schemas for all Firestore documents
  (GameState, PlayerState, HandDoc, DeckDoc) and typed parse functions
- Remove phantom `deck` field from PlayerState (was never stored on game doc;
  decks live in games/{roomId}/decks/{uid} subcollection)
- Add HandDoc/DeckDoc interfaces to types.ts for subcollection documents
- Replace 75+ unsafe `as` casts across game-engine.ts, dealer.ts, and
  player-actions.ts with schema-validated parse calls
- Add Zod request validation for Cloud Functions (joinGame, placeCards)
- Extract `preserveObservers` helper to deduplicate observer-preservation
  pattern repeated across 4 game-engine functions
- Extract `newPlayerState` factory in player-actions.ts
- Update frontend hooks to use parseGameState/parseHandDoc instead of
  raw `snap.data() as GameState` casts
- Update test data to include all required fields for schema validation
- Install zod in frontend, functions, and dealer workspaces

https://claude.ai/code/session_01AsqSXsnSsLEFPFwHVXzeDy