### PR TITLE
Fix dealer crash-loop and harden deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,9 +119,17 @@ jobs:
         env:
           VM_IP: ${{ secrets.GCE_VM_IP }}
         run: |
-          sleep 3
-          ssh -i ~/.ssh/deploy_key deploy@${VM_IP} \
-            "curl -sf http://localhost:8080/health"
+          for i in 1 2 3 4 5; do
+            sleep 3
+            if ssh -i ~/.ssh/deploy_key deploy@${VM_IP} \
+              "curl -sf http://localhost:8080/health"; then
+              echo "Dealer is healthy"
+              exit 0
+            fi
+            echo "Attempt $i failed, retrying..."
+          done
+          echo "Dealer health check failed after 5 attempts"
+          exit 1
 
       - name: Clean up SSH key
         if: always()
@@ -140,6 +148,18 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Verify dealer is healthy
+        env:
+          VM_IP: ${{ secrets.GCE_VM_IP }}
+        run: |
+          mkdir -p ~/.ssh
+          echo '${{ secrets.GCE_SSH_PRIVATE_KEY }}' > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${VM_IP} >> ~/.ssh/known_hosts 2>/dev/null
+          ssh -i ~/.ssh/deploy_key deploy@${VM_IP} \
+            "curl -sf http://localhost:8080/health"
+          rm -f ~/.ssh/deploy_key
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/dealer/src/dealer.ts
+++ b/dealer/src/dealer.ts
@@ -87,7 +87,13 @@ export class Dealer {
   }
 
   private onGameSnapshot(roomId: string, doc: FirebaseFirestore.QueryDocumentSnapshot): void {
-    const game = parseGameState(doc.data());
+    let game: GameState;
+    try {
+      game = parseGameState(doc.data());
+    } catch (err) {
+      console.error(`[Dealer] [${roomId}] Skipping unparseable game document:`, err);
+      return;
+    }
 
     console.log(`[Dealer] [${roomId}] Snapshot: phase=${game.phase}, street=${game.street}, players=${game.playerOrder.length}`);
 


### PR DESCRIPTION
## Summary
- **Fix dealer crash-loop**: Stale `games/current` doc from pre-multi-room era caused `parseGameState` (Zod) to throw uncaught, crash-looping the dealer process (316 restarts). Added try/catch in `onGameSnapshot` to skip unparseable docs gracefully.
- **Harden deploy health check**: Added retry logic (5 attempts, 3s apart) to dealer health check after deploy, replacing the single-shot check.
- **Add smoke-test pre-flight**: Verify dealer is healthy before running E2E smoke tests against production.

## Test plan
- [x] Verified production is working after deleting stale `games/current` doc
- [x] Dealer no longer crash-loops on bad docs (try/catch prevents uncaught throw)
- [ ] CI deploy pipeline passes with retry health check
- [ ] Smoke tests pass with dealer health pre-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)