### PR TITLE
Re-land dealer crash-loop fix and deploy hardening

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -119,9 +119,17 @@ jobs:
         env:
           VM_IP: ${{ secrets.GCE_VM_IP }}
         run: |
-          sleep 3
-          ssh -i ~/.ssh/deploy_key deploy@${VM_IP} \
-            "curl -sf http://localhost:8080/health"
+          for i in 1 2 3 4 5; do
+            sleep 3
+            if ssh -i ~/.ssh/deploy_key deploy@${VM_IP} \
+              "curl -sf http://localhost:8080/health"; then
+              echo "Dealer is healthy"
+              exit 0
+            fi
+            echo "Attempt $i failed, retrying..."
+          done
+          echo "Dealer health check failed after 5 attempts"
+          exit 1
 
       - name: Clean up SSH key
         if: always()
@@ -140,6 +148,18 @@ jobs:
           cache: npm
 
       - run: npm ci
+
+      - name: Verify dealer is healthy
+        env:
+          VM_IP: ${{ secrets.GCE_VM_IP }}
+        run: |
+          mkdir -p ~/.ssh
+          echo '${{ secrets.GCE_SSH_PRIVATE_KEY }}' > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H ${VM_IP} >> ~/.ssh/known_hosts 2>/dev/null
+          ssh -i ~/.ssh/deploy_key deploy@${VM_IP} \
+            "curl -sf http://localhost:8080/health"
+          rm -f ~/.ssh/deploy_key
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/dealer/src/dealer.ts
+++ b/dealer/src/dealer.ts
@@ -87,7 +87,13 @@ export class Dealer {
   }
 
   private onGameSnapshot(roomId: string, doc: FirebaseFirestore.QueryDocumentSnapshot): void {
-    const game = parseGameState(doc.data());
+    let game: GameState;
+    try {
+      game = parseGameState(doc.data());
+    } catch (err) {
+      console.error(`[Dealer] [${roomId}] Skipping unparseable game document:`, err);
+      return;
+    }
 
     console.log(`[Dealer] [${roomId}] Snapshot: phase=${game.phase}, street=${game.street}, players=${game.playerOrder.length}`);
 


### PR DESCRIPTION
## Summary
- Re-lands PR #11 (fix dealer crash-loop on unparseable Firestore docs)
- Depends on PR #15 (Zod schemas) and PR #16 (bot players)
- Wraps `parseGameState` in try-catch in dealer's `onGameSnapshot` so unparseable docs are skipped instead of crash-looping the process
- Hardens deploy pipeline: retry loop for dealer health check, verify dealer health before smoke tests

## Test plan
- [x] All 7 E2E tests pass locally with `-x` (fail-fast)
- [x] CI E2E gate will validate on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)