### PR TITLE
Use list reporter for E2E tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
           cat .logs/dealer.log 2>/dev/null || echo "(no dealer log)"
 
       - name: Run E2E tests
-        run: npm test
+        run: npx playwright test --reporter=list
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary
- Switches Playwright from default `dot` reporter to `list` in CI
- Each test name and pass/fail status prints as it runs, making CI logs easier to read

## Test plan
- [ ] Check CI output shows individual test names

🤖 Generated with [Claude Code](https://claude.com/claude-code)