### PR TITLE
Add React Compiler, remove manual memoization

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.1",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { useAuth } from './hooks/useAuth.ts';
 import { useGameState } from './hooks/useGameState.ts';
 import { usePlayerHand } from './hooks/usePlayerHand.ts';
@@ -38,15 +38,15 @@ function App() {
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
-  const handleRoomJoined = useCallback((newRoomId: string) => {
+  const handleRoomJoined = (newRoomId: string) => {
     setRoomId(newRoomId);
     setRoomInUrl(newRoomId);
-  }, []);
+  };
 
-  const handleLeaveRoom = useCallback(() => {
+  const handleLeaveRoom = () => {
     setRoomId(null);
     setRoomInUrl(null);
-  }, []);
+  };
 
   if (authLoading) {
     return (

--- a/frontend/src/components/HandPanel.tsx
+++ b/frontend/src/components/HandPanel.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import type { Card, GameState } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
 import { RANK_NAMES } from '@shared/core/constants';
@@ -45,10 +44,10 @@ export function HandPanel({
     ? alreadyPlaced >= 5 && hand.length === 0
     : alreadyPlaced > 0 && hand.length === 0;
 
-  const handleCardClick = useCallback((index: number) => {
+  const handleCardClick = (index: number) => {
     if (submitting) return;
     onSelectCard(selectedIndex === index ? null : index);
-  }, [selectedIndex, submitting, onSelectCard]);
+  };
 
   const allPlaced = placements.length >= requiredPlacements;
 

--- a/frontend/src/components/Lobby.tsx
+++ b/frontend/src/components/Lobby.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { functions, trackEvent } from '../firebase.ts';
 import type { GameState, MatchSettings } from '@shared/core/types';
@@ -44,7 +44,7 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
   const isHost = gameState?.hostUid === uid;
   const canStart = isHost && (gameState?.playerOrder.length ?? 0) >= 2;
 
-  const handleJoin = useCallback(async () => {
+  const handleJoin = async () => {
     if (!nameInput.trim()) return;
     setJoining(true);
     try {
@@ -59,9 +59,9 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
     } finally {
       setJoining(false);
     }
-  }, [nameInput, setDisplayName, signIn, roomId, gameState]);
+  };
 
-  const handleStart = useCallback(async () => {
+  const handleStart = async () => {
     setStarting(true);
     try {
       const startMatchFn = httpsCallable(functions, 'startMatch');
@@ -76,9 +76,9 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
       setToast('Failed to start match');
       setStarting(false);
     }
-  }, [roomId, turnTimeoutMs]);
+  };
 
-  const handleLeave = useCallback(async () => {
+  const handleLeave = async () => {
     setLeaving(true);
     try {
       const leaveGameFn = httpsCallable(functions, 'leaveGame');
@@ -90,9 +90,9 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
       setToast('Failed to leave game');
       setLeaving(false);
     }
-  }, [roomId, onLeaveRoom]);
+  };
 
-  const handleAddBot = useCallback(async () => {
+  const handleAddBot = async () => {
     setAddingBot(true);
     try {
       const addBotFn = httpsCallable(functions, 'addBot');
@@ -103,9 +103,9 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
     } finally {
       setAddingBot(false);
     }
-  }, [roomId]);
+  };
 
-  const handleRemoveBot = useCallback(async (botUid: string) => {
+  const handleRemoveBot = async (botUid: string) => {
     try {
       const removeBotFn = httpsCallable(functions, 'removeBot');
       await removeBotFn({ roomId, botUid });
@@ -113,7 +113,7 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
       console.error('Failed to remove bot:', err);
       setToast('Failed to remove bot');
     }
-  }, [roomId]);
+  };
 
   // In-game lobby view (waiting for host to start)
   if (isInGame && gameState) {

--- a/frontend/src/components/MatchResults.tsx
+++ b/frontend/src/components/MatchResults.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import type { GameState } from '@shared/core/types';
 import { scorePairwise } from '@shared/game-logic/scoring';
@@ -38,7 +38,7 @@ export function MatchResults({ gameState, currentUid, roomId }: MatchResultsProp
     .map((uid) => gameState.players[uid])
     .filter(Boolean);
 
-  const handlePlayAgain = useCallback(async () => {
+  const handlePlayAgain = async () => {
     setRestarting(true);
     try {
       const playAgainFn = httpsCallable(functions, 'playAgain');
@@ -48,7 +48,7 @@ export function MatchResults({ gameState, currentUid, roomId }: MatchResultsProp
       console.error('Failed to restart:', err);
       setRestarting(false);
     }
-  }, [roomId]);
+  };
 
   return (
     <div data-testid="match-results" className="fixed inset-0 bg-black/80 flex items-center justify-center z-50 font-mono">

--- a/frontend/src/components/RoomSelector.tsx
+++ b/frontend/src/components/RoomSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import { functions, trackEvent } from '../firebase.ts';
 import { generateRoomCode } from '../utils/roomCode.ts';
@@ -23,7 +23,7 @@ export function RoomSelector({ displayName, setDisplayName, signIn, onRoomJoined
     return () => clearTimeout(t);
   }, [toast]);
 
-  const handleCreate = useCallback(async () => {
+  const handleCreate = async () => {
     if (!nameInput.trim()) return;
     setCreating(true);
     try {
@@ -40,9 +40,9 @@ export function RoomSelector({ displayName, setDisplayName, signIn, onRoomJoined
     } finally {
       setCreating(false);
     }
-  }, [nameInput, setDisplayName, signIn, onRoomJoined]);
+  };
 
-  const handleJoin = useCallback(async () => {
+  const handleJoin = async () => {
     if (!nameInput.trim() || !roomCodeInput.trim()) return;
     setJoining(true);
     try {
@@ -59,7 +59,7 @@ export function RoomSelector({ displayName, setDisplayName, signIn, onRoomJoined
     } finally {
       setJoining(false);
     }
-  }, [nameInput, roomCodeInput, setDisplayName, signIn, onRoomJoined]);
+  };
 
   return (
     <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center font-mono">

--- a/frontend/src/components/mobile/MobileGamePage.tsx
+++ b/frontend/src/components/mobile/MobileGamePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import type { GameState, Card, Row, Board } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
@@ -75,7 +75,7 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
   const placedCardKeys = new Set(placements.map((p) => cardKey(p.card)));
   const remainingHand = hand.filter((c) => !placedCardKeys.has(cardKey(c)));
 
-  const mergedBoard = useMemo((): Board => {
+  const mergedBoard = ((): Board => {
     const player = gameState.players[uid];
     if (!player) return { top: [], middle: [], bottom: [] };
     const board: Board = {
@@ -92,9 +92,9 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
       }
     }
     return board;
-  }, [gameState.players, uid, placements]);
+  })();
 
-  const handleRowClick = useCallback(async (row: Row) => {
+  const handleRowClick = async (row: Row) => {
     if (selectedIndex === null || submitting) return;
     const card = remainingHand[selectedIndex];
     if (!card) return;
@@ -130,9 +130,9 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
         setSubmitting(false);
       }
     }
-  }, [selectedIndex, remainingHand, mergedBoard, placements, submitting, requiredPlacements, isStreet, hand, roomId, gameState.street]);
+  };
 
-  const handleLeave = useCallback(async () => {
+  const handleLeave = async () => {
     setLeaving(true);
     try {
       const leaveGameFn = httpsCallable(functions, 'leaveGame');
@@ -144,7 +144,7 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
       setToast('Failed to leave game');
       setLeaving(false);
     }
-  }, [roomId, onLeaveRoom]);
+  };
 
   const isObserver = !gameState.playerOrder.includes(uid);
   const currentPlayer = gameState.players[uid];

--- a/frontend/src/components/mobile/MobileHandArea.tsx
+++ b/frontend/src/components/mobile/MobileHandArea.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from 'react';
 import type { Card, GameState } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
 import { CardComponent } from '../CardComponent.tsx';
@@ -35,10 +34,10 @@ export function MobileHandArea({
     ? alreadyPlaced >= 5 && hand.length === 0
     : alreadyPlaced > 0 && hand.length === 0;
 
-  const handleCardClick = useCallback((index: number) => {
+  const handleCardClick = (index: number) => {
     if (submitting) return;
     onSelectCard(selectedIndex === index ? null : index);
-  }, [selectedIndex, submitting, onSelectCard]);
+  };
 
   const allPlaced = placements.length >= requiredPlacements;
 

--- a/frontend/src/components/mobile/MobileMatchOverlay.tsx
+++ b/frontend/src/components/mobile/MobileMatchOverlay.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { httpsCallable } from 'firebase/functions';
 import type { GameState } from '@shared/core/types';
 import { scorePairwise } from '@shared/game-logic/scoring';
@@ -35,7 +35,7 @@ export function MobileMatchOverlay({ gameState, currentUid, roomId }: MobileMatc
     .map((uid) => gameState.players[uid])
     .filter(Boolean);
 
-  const handlePlayAgain = useCallback(async () => {
+  const handlePlayAgain = async () => {
     setRestarting(true);
     try {
       const playAgainFn = httpsCallable(functions, 'playAgain');
@@ -45,7 +45,7 @@ export function MobileMatchOverlay({ gameState, currentUid, roomId }: MobileMatc
       console.error('Failed to restart:', err);
       setRestarting(false);
     }
-  }, [roomId]);
+  };
 
   return (
     <div data-testid="mobile-match-overlay" className="fixed inset-0 bg-gray-900 z-50 flex flex-col items-center justify-center px-6 font-mono overflow-y-auto">

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { signInAnonymously, onAuthStateChanged, type User } from 'firebase/auth';
 import { auth } from '../firebase.ts';
 
@@ -19,17 +19,17 @@ export function useAuth() {
     return unsub;
   }, []);
 
-  const signIn = useCallback(async () => {
+  const signIn = async () => {
     if (!auth.currentUser) {
       await signInAnonymously(auth);
     }
-  }, []);
+  };
 
-  const setDisplayName = useCallback((name: string) => {
+  const setDisplayName = (name: string) => {
     const trimmed = name.trim();
     setDisplayNameState(trimmed);
     localStorage.setItem(DISPLAY_NAME_KEY, trimmed);
-  }, []);
+  };
 
   return { user, loading, displayName, setDisplayName, signIn };
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,14 @@ import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react({
+      babel: {
+        plugins: ['babel-plugin-react-compiler'],
+      },
+    }),
+    tailwindcss(),
+  ],
   resolve: {
     alias: {
       '@shared': path.resolve(__dirname, '../shared'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,7 @@
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
@@ -3332,6 +3333,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz",
+      "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",


### PR DESCRIPTION
## Summary
- Adds `babel-plugin-react-compiler` (v1.0) to the frontend Vite build
- Removes all manual `useCallback` and `useMemo` wrappers across 10 frontend files
- React Compiler handles memoization automatically, producing better optimization decisions than manual wrappers

## Changes
- `frontend/vite.config.ts` — enable React Compiler via Babel plugin
- `frontend/package.json` — add `babel-plugin-react-compiler` devDependency
- 10 component/hook files — replace `useCallback`/`useMemo` with plain functions/expressions

## Test plan
- [x] `npm run build` passes (compiler active during production build)
- [x] `npm run lint -w frontend` passes
- [x] `npm run test:unit` passes (77 shared + 18 dealer tests)
- [ ] CI check + E2E tests pass
- [ ] Manual smoke test in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)