### PR TITLE
Reduce frontend tech debt: deduplicate and remove dead code

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,10 @@
+import { httpsCallable } from 'firebase/functions';
+import { functions } from './firebase.ts';
+
+export const joinGame = httpsCallable(functions, 'joinGame');
+export const leaveGame = httpsCallable(functions, 'leaveGame');
+export const placeCards = httpsCallable(functions, 'placeCards');
+export const startMatch = httpsCallable(functions, 'startMatch');
+export const playAgain = httpsCallable(functions, 'playAgain');
+export const addBot = httpsCallable(functions, 'addBot');
+export const removeBot = httpsCallable(functions, 'removeBot');

--- a/frontend/src/components/CardComponent.tsx
+++ b/frontend/src/components/CardComponent.tsx
@@ -24,35 +24,16 @@ const SUIT_SELECTED_RING: Record<string, string> = {
   c: 'ring-green-300',
 };
 
-export type CardSize = 'xs' | 'sm' | 'md' | 'lg';
-
-const SIZE_CLASSES: Record<CardSize, string> = {
-  xs: 'w-6 h-8 text-[7px] rounded-sm',
-  sm: 'w-8 h-11 text-[10px] rounded',
-  md: 'w-10 h-14 text-xs rounded-md',
-  lg: 'w-14 h-20 text-sm rounded-lg',
-};
-
-const RANK_SIZE: Record<CardSize, string> = {
-  xs: 'text-[10px] leading-none',
-  sm: 'text-sm leading-none',
-  md: 'text-base leading-none',
-  lg: 'text-xl leading-none',
-};
-
 export const CARD_ASPECT = 1.4;
 
 interface CardProps {
   card: Card | null;
-  faceDown?: boolean;
+  widthPx: number;
   selected?: boolean;
   onClick?: () => void;
-  size?: CardSize;
-  /** Pixel width — when set, card dimensions are computed from this instead of size presets. */
-  widthPx?: number;
 }
 
-function pxStyles(w: number) {
+function cardStyles(w: number) {
   return {
     card: {
       width: w,
@@ -66,25 +47,16 @@ function pxStyles(w: number) {
   };
 }
 
-export function CardComponent({ card, faceDown, selected, onClick, size, widthPx }: CardProps) {
-  const px = widthPx !== undefined;
-  const resolvedSize: CardSize = size ?? 'lg';
-  const ps = px ? pxStyles(widthPx!) : null;
-  const sizeClass = px ? '' : SIZE_CLASSES[resolvedSize];
-  const rankClass = px ? '' : RANK_SIZE[resolvedSize];
+export function CardComponent({ card, widthPx, selected, onClick }: CardProps) {
+  const s = cardStyles(widthPx);
 
-  if (!card || faceDown) {
+  if (!card) {
     return (
       <div
-        className={`
-          ${sizeClass}
-          border-2 border-gray-600 bg-gray-800
-          flex items-center justify-center cursor-default
-          bg-[repeating-linear-gradient(45deg,transparent,transparent_4px,rgba(255,255,255,0.05)_4px,rgba(255,255,255,0.05)_8px)]
-        `}
-        style={ps?.card}
+        className="border-2 border-gray-600 bg-gray-800 flex items-center justify-center cursor-default bg-[repeating-linear-gradient(45deg,transparent,transparent_4px,rgba(255,255,255,0.05)_4px,rgba(255,255,255,0.05)_8px)]"
+        style={s.card}
       >
-        {!card && <span className="text-gray-500">-</span>}
+        <span className="text-gray-500">-</span>
       </div>
     );
   }
@@ -98,15 +70,14 @@ export function CardComponent({ card, faceDown, selected, onClick, size, widthPx
     <div
       onClick={onClick}
       className={`
-        ${sizeClass}
         border-2 ${bg} ${border} flex flex-col items-center justify-center
         font-bold select-none transition-all text-white
         ${selected ? `border-yellow-400 ring-2 ${ring} -translate-y-2 shadow-lg shadow-yellow-900/30` : ''}
         ${onClick ? 'cursor-pointer hover:brightness-125 hover:-translate-y-1' : 'cursor-default'}
       `}
-      style={ps?.card}
+      style={s.card}
     >
-      <span className={rankClass} style={ps?.rank}>{rank}</span>
+      <span style={s.rank}>{rank}</span>
     </div>
   );
 }

--- a/frontend/src/components/PairwiseBreakdown.tsx
+++ b/frontend/src/components/PairwiseBreakdown.tsx
@@ -1,0 +1,36 @@
+import type { PlayerState, RoundResult } from '@shared/core/types';
+import { scorePairwise } from '@shared/game-logic/scoring';
+import { pairwiseLabel } from '../utils/scoring-display.ts';
+
+interface PairwiseBreakdownProps {
+  players: PlayerState[];
+  roundResults: Record<string, RoundResult>;
+}
+
+export function PairwiseBreakdown({ players, roundResults }: PairwiseBreakdownProps) {
+  if (players.length < 2) return null;
+
+  return (
+    <div className="text-xs text-gray-500 border-t border-gray-800 pt-2">
+      <div className="font-bold text-gray-400 mb-1">Pairwise</div>
+      {players.map((pA, i) =>
+        players.slice(i + 1).map((pB) => {
+          const aFouled = roundResults[pA.uid]?.fouled ?? false;
+          const bFouled = roundResults[pB.uid]?.fouled ?? false;
+          const result = scorePairwise(
+            pA.uid, aFouled, pA.board,
+            pB.uid, bFouled, pB.board,
+          );
+          return (
+            <div key={`${pA.uid}-${pB.uid}`} className="flex justify-between gap-2 mb-1">
+              <span className="text-gray-400 truncate">{pA.displayName} vs {pB.displayName}</span>
+              <span className="whitespace-nowrap">
+                {pairwiseLabel(result.rowPoints, result.scoopBonus, result.total, aFouled, bFouled)}
+              </span>
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/PlayerBoard.tsx
+++ b/frontend/src/components/PlayerBoard.tsx
@@ -1,48 +1,19 @@
-import type { CSSProperties } from 'react';
-import type { Board, Card, Row } from '@shared/core/types';
+import type { Board, Card } from '@shared/core/types';
+import { Row } from '@shared/core/types';
 import { CardComponent, CARD_ASPECT } from './CardComponent.tsx';
-import type { CardSize } from './CardComponent.tsx';
 
-const SPACER_W: Record<CardSize, string> = {
-  xs: 'w-6',
-  sm: 'w-8',
-  md: 'w-10',
-  lg: 'w-14',
-};
-
-const EMPTY_SLOT: Record<CardSize, string> = {
-  xs: 'w-6 h-8 rounded-sm',
-  sm: 'w-8 h-11 rounded',
-  md: 'w-10 h-14 rounded-md',
-  lg: 'w-14 h-20 rounded-lg',
-};
-
-interface SlotProps {
-  card: Card | null;
-  size?: CardSize;
-  widthPx?: number;
-}
-
-function CardSlot({ card, size = 'lg', widthPx }: SlotProps) {
+function CardSlot({ card, widthPx }: { card: Card | null; widthPx: number }) {
   if (card) {
-    return <CardComponent card={card} size={size} widthPx={widthPx} />;
+    return <CardComponent card={card} widthPx={widthPx} />;
   }
-
-  const pxStyle: CSSProperties | undefined = widthPx !== undefined ? {
-    width: widthPx,
-    height: Math.round(widthPx * CARD_ASPECT),
-    borderRadius: Math.max(2, Math.round(widthPx * 0.1)),
-  } : undefined;
-
   return (
     <div
-      className={`
-        ${widthPx !== undefined ? '' : EMPTY_SLOT[size]}
-        border-2 border-dashed
-        flex items-center justify-center
-        border-gray-600 bg-gray-800/30
-      `}
-      style={pxStyle}
+      className="border-2 border-dashed flex items-center justify-center border-gray-600 bg-gray-800/30"
+      style={{
+        width: widthPx,
+        height: Math.round(widthPx * CARD_ASPECT),
+        borderRadius: Math.max(2, Math.round(widthPx * 0.1)),
+      }}
     />
   );
 }
@@ -60,22 +31,16 @@ interface PlayerBoardProps {
   isCurrentPlayer?: boolean;
   onRowClick?: (row: Row) => void;
   hasCardSelected?: boolean;
-  cardSize?: CardSize;
-  /** Pixel width for cards — overrides cardSize when set. */
-  cardWidthPx?: number;
+  cardWidthPx: number;
   score?: number;
   hasPlaced?: boolean;
-  isObserver?: boolean;
   disconnected?: boolean;
-  isBot?: boolean;
 }
 
 export function PlayerBoard({
   board, playerName, fouled, isCurrentPlayer, onRowClick, hasCardSelected,
-  cardSize, cardWidthPx, score, hasPlaced, isObserver, disconnected, isBot,
+  cardWidthPx, score, hasPlaced, disconnected,
 }: PlayerBoardProps) {
-  const size: CardSize = cardSize ?? 'lg';
-  const px = cardWidthPx !== undefined;
   const topSlots = padRow(board.top, 3);
   const middleSlots = padRow(board.middle, 5);
   const bottomSlots = padRow(board.bottom, 5);
@@ -87,36 +52,24 @@ export function PlayerBoard({
   const rowClickable = (hasSpace: boolean) =>
     isCurrentPlayer && hasCardSelected && onRowClick && hasSpace;
 
-  // Pixel-mode: proportional gap and padding
-  const gap = px ? Math.max(2, Math.round(cardWidthPx! * 0.06)) : undefined;
-  const boardPad = px ? Math.max(4, Math.round(cardWidthPx! * 0.12)) : undefined;
-  const headerFs = px ? Math.max(8, Math.round(cardWidthPx! * 0.22)) : undefined;
-
-  const isSmallText = !px && (size === 'sm' || size === 'md');
+  const gap = Math.max(2, Math.round(cardWidthPx * 0.06));
+  const boardPad = Math.max(4, Math.round(cardWidthPx * 0.12));
+  const headerFs = Math.max(8, Math.round(cardWidthPx * 0.22));
+  const boardMaxW = 5 * cardWidthPx + 4 * gap + 2 * boardPad + 4;
 
   const rowClass = (clickable: boolean) => `
-    flex justify-center ${px ? '' : 'gap-1'} rounded px-1 py-0.5 transition-colors
+    flex justify-center rounded px-1 py-0.5 transition-colors
     ${clickable ? 'cursor-pointer bg-yellow-900/20 hover:bg-yellow-900/40 ring-1 ring-yellow-500/40' : ''}
   `;
 
-  // In pixel mode, constrain board width so long names don't stretch the grid
-  // Board width = 5 cards + 4 gaps + 2 spacers (top row) + 2*padding + 2*border
-  const boardMaxW = px
-    ? 5 * cardWidthPx! + 4 * gap! + 2 * boardPad! + 4
-    : undefined;
-
   return (
     <div
-      className={`
-        border overflow-hidden
-        ${px ? '' : 'p-2'}
-        ${isCurrentPlayer ? 'border-green-600 bg-green-900/20' : 'border-gray-700 bg-gray-800/20'}
-      `}
-      style={boardPad !== undefined ? { padding: boardPad, maxWidth: boardMaxW } : undefined}
+      className={`border overflow-hidden ${isCurrentPlayer ? 'border-green-600 bg-green-900/20' : 'border-gray-700 bg-gray-800/20'}`}
+      style={{ padding: boardPad, maxWidth: boardMaxW }}
     >
       <div
-        className={`text-center mb-1 ${!px ? (isSmallText ? 'text-xs' : 'text-sm') : ''} text-gray-300 flex items-center justify-center gap-1 flex-wrap`}
-        style={headerFs ? { fontSize: headerFs, lineHeight: '1.2' } : undefined}
+        className="text-center mb-1 text-gray-300 flex items-center justify-center gap-1 flex-wrap"
+        style={{ fontSize: headerFs, lineHeight: '1.2' }}
       >
         <span className="truncate max-w-[10em]">{playerName}</span>
         {score !== undefined && (
@@ -129,51 +82,43 @@ export function PlayerBoard({
         )}
         {fouled && <span className="text-red-400">[F]</span>}
         {disconnected && <span className="text-red-500">[DC]</span>}
-        {isObserver && <span className="text-blue-400">[OBS]</span>}
-        {isBot && <span className="text-cyan-400">[BOT]</span>}
       </div>
 
       {/* Top row - 3 cards, centered with spacers to match 5-card row width */}
       <div
         data-testid="row-top"
-        onClick={rowClickable(topHasSpace) ? () => onRowClick!('top' as Row) : undefined}
+        onClick={rowClickable(topHasSpace) ? () => onRowClick!(Row.Top) : undefined}
         className={`${rowClass(!!rowClickable(topHasSpace))} mb-1`}
-        style={gap ? { gap } : undefined}
+        style={{ gap }}
       >
-        {px
-          ? <div style={{ width: cardWidthPx }} />
-          : <div className={SPACER_W[size]} />
-        }
+        <div style={{ width: cardWidthPx }} />
         {topSlots.map((card, i) => (
-          <CardSlot key={`top-${i}`} card={card} size={size} widthPx={cardWidthPx} />
+          <CardSlot key={`top-${i}`} card={card} widthPx={cardWidthPx} />
         ))}
-        {px
-          ? <div style={{ width: cardWidthPx }} />
-          : <div className={SPACER_W[size]} />
-        }
+        <div style={{ width: cardWidthPx }} />
       </div>
 
       {/* Middle row - 5 cards */}
       <div
         data-testid="row-middle"
-        onClick={rowClickable(middleHasSpace) ? () => onRowClick!('middle' as Row) : undefined}
+        onClick={rowClickable(middleHasSpace) ? () => onRowClick!(Row.Middle) : undefined}
         className={`${rowClass(!!rowClickable(middleHasSpace))} mb-1`}
-        style={gap ? { gap } : undefined}
+        style={{ gap }}
       >
         {middleSlots.map((card, i) => (
-          <CardSlot key={`mid-${i}`} card={card} size={size} widthPx={cardWidthPx} />
+          <CardSlot key={`mid-${i}`} card={card} widthPx={cardWidthPx} />
         ))}
       </div>
 
       {/* Bottom row - 5 cards */}
       <div
         data-testid="row-bottom"
-        onClick={rowClickable(bottomHasSpace) ? () => onRowClick!('bottom' as Row) : undefined}
+        onClick={rowClickable(bottomHasSpace) ? () => onRowClick!(Row.Bottom) : undefined}
         className={rowClass(!!rowClickable(bottomHasSpace))}
-        style={gap ? { gap } : undefined}
+        style={{ gap }}
       >
         {bottomSlots.map((card, i) => (
-          <CardSlot key={`bot-${i}`} card={card} size={size} widthPx={cardWidthPx} />
+          <CardSlot key={`bot-${i}`} card={card} widthPx={cardWidthPx} />
         ))}
       </div>
     </div>

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -1,0 +1,12 @@
+interface ToastProps {
+  message: string | null;
+}
+
+export function Toast({ message }: ToastProps) {
+  if (!message) return null;
+  return (
+    <div className="fixed top-4 left-1/2 -translate-x-1/2 bg-red-900 border border-red-700 px-4 py-2 text-xs text-red-300 shadow-lg z-50 rounded">
+      {message}
+    </div>
+  );
+}

--- a/frontend/src/components/mobile/MobileGamePage.tsx
+++ b/frontend/src/components/mobile/MobileGamePage.tsx
@@ -1,48 +1,40 @@
-import { useState, useEffect, useRef, useLayoutEffect } from 'react';
-import { httpsCallable } from 'firebase/functions';
-import type { GameState, Card, Row, Board } from '@shared/core/types';
+import { useState, useLayoutEffect, useRef } from 'react';
+import type { Card, Row, Board } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
-import { functions, trackEvent } from '../../firebase.ts';
-import { PlayerBoard } from '../PlayerBoard.tsx';
+import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT } from '@shared/core/constants';
+import { placeCards, leaveGame } from '../../api.ts';
+import { trackEvent } from '../../firebase.ts';
 import { useCountdown } from '../../hooks/useCountdown.ts';
+import { useToast } from '../../hooks/useToast.ts';
+import { cardKey, boardCardCount, expectedCardsForStreet } from '../../utils/card-utils.ts';
+import type { Placement } from '../../utils/card-utils.ts';
+import { PlayerBoard } from '../PlayerBoard.tsx';
+import { Toast } from '../Toast.tsx';
 import { MobileOpponentGrid } from './MobileOpponentGrid.tsx';
 import { MobileHandArea } from './MobileHandArea.tsx';
 import { MobileRoundOverlay } from './MobileRoundOverlay.tsx';
 import { MobileMatchOverlay } from './MobileMatchOverlay.tsx';
 
-function cardKey(c: Card): string {
-  return `${c.rank}-${c.suit}`;
-}
-
-interface Placement {
-  card: Card;
-  row: Row;
-}
+const STREET_PHASES = new Set<string>([
+  GamePhase.Street2,
+  GamePhase.Street3,
+  GamePhase.Street4,
+  GamePhase.Street5,
+]);
 
 // --- Card size computation ---
-// Given a container's width and height, compute the largest card width
-// such that everything fits without scrolling.
 
 function computePlayerCardWidth(w: number, h: number): number {
   if (w <= 0 || h <= 0) return 0;
-  // Width: board is 5 cards + 4 gaps(~6% each) + 2 padding(~12% each) + 2px border
-  // ≈ 5*cw + 0.24*cw + 0.24*cw + 10 ≈ 5.48*cw + 10
   const fromWidth = (w - 10) / 5.48;
-  // Height: 3 board rows + 1 hand row = 4 rows of cards
-  // + board header(~20px) + row margins(~12px) + board padding(~0.24*cw) + border(2px)
-  // + hand padding(~20px) + instruction text(~16px) + gap between board & hand(~8px)
-  // ≈ 4 * cw * 1.4 + 0.24*cw + 78 ≈ 5.84*cw + 78
   const fromHeight = (h - 78) / 5.84;
   return Math.max(8, Math.floor(Math.min(fromWidth, fromHeight)));
 }
 
-/** Per-board width: 5 cards + 4 gaps(0.06*cw) + padding(0.24*cw) + row px-1(8) + border(4) + buffer
- *  = 5.48*cw + 16 */
+/** Per-board width: 5 cards + 4 gaps(0.06*cw) + padding(0.24*cw) + row px-1(8) + border(4) + buffer */
 const BOARD_W_COEFF = 5.48;
 const BOARD_W_FIXED = 16;
-/** Per-board height: 3 rows + header + padding + border + row margins
- *  3*1.4*cw (cards) + 0.24*cw (padding) = 4.44*cw
- *  header(~12) + border(4) + row margins(8) + row py(12) + buffer(6) = 42 */
+/** Per-board height: 3 rows + header + padding + border + row margins */
 const BOARD_H_COEFF = 4.44;
 const BOARD_H_FIXED = 42;
 /** Gap between boards as fraction of cw */
@@ -59,15 +51,10 @@ function computeOpponentGridLayout(w: number, h: number, n: number): OpponentGri
 
   let best: OpponentGridLayout = { cols: 1, rows: n, cardWidth: 0 };
 
-  // Try every possible column count and pick the one that maximizes card size
   for (let cols = 1; cols <= n; cols++) {
     const rows = Math.ceil(n / cols);
-    // Width constraint: cols boards + (cols-1) gaps
-    // cols * (BOARD_W_COEFF*cw + BOARD_W_FIXED) + (cols-1) * BOARD_GAP_COEFF*cw ≤ w
-    // cw * (cols*BOARD_W_COEFF + (cols-1)*BOARD_GAP_COEFF) + cols*BOARD_W_FIXED ≤ w
     const wCoeff = cols * BOARD_W_COEFF + (cols - 1) * BOARD_GAP_COEFF;
     const fromWidth = (w - cols * BOARD_W_FIXED) / wCoeff;
-    // Height constraint: rows boards + (rows-1) gaps
     const hCoeff = rows * BOARD_H_COEFF + (rows - 1) * BOARD_GAP_COEFF;
     const fromHeight = (h - rows * BOARD_H_FIXED) / hCoeff;
     const cw = Math.floor(Math.min(fromWidth, fromHeight));
@@ -97,7 +84,7 @@ function useContainerSize(ref: React.RefObject<HTMLDivElement | null>) {
 // --- Component ---
 
 interface MobileGamePageProps {
-  gameState: GameState;
+  gameState: import('@shared/core/types').GameState;
   hand: Card[];
   uid: string;
   roomId: string;
@@ -109,38 +96,24 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
   const [placements, setPlacements] = useState<Placement[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [leaving, setLeaving] = useState(false);
-  const [toast, setToast] = useState<string | null>(null);
+  const { message: toast, showToast } = useToast();
 
-  // Section refs for measuring
   const opponentRef = useRef<HTMLDivElement>(null);
   const playerRef = useRef<HTMLDivElement>(null);
   const opponentSize = useContainerSize(opponentRef);
   const playerSize = useContainerSize(playerRef);
 
-  // Auto-dismiss toast
-  useEffect(() => {
-    if (!toast) return;
-    const t = setTimeout(() => setToast(null), 3000);
-    return () => clearTimeout(t);
-  }, [toast]);
-
   const countdown = useCountdown(gameState.phaseDeadline);
   const showTimer = (
-    gameState.phase === GamePhase.InitialDeal ||
-    gameState.phase === GamePhase.Street2 ||
-    gameState.phase === GamePhase.Street3 ||
-    gameState.phase === GamePhase.Street4 ||
-    gameState.phase === GamePhase.Street5
+    gameState.phase === GamePhase.InitialDeal || STREET_PHASES.has(gameState.phase)
   );
 
   const isRoundComplete = gameState.phase === GamePhase.Complete;
   const isMatchComplete = gameState.phase === GamePhase.MatchComplete;
 
   const isInitialDeal = gameState.phase === GamePhase.InitialDeal;
-  const isStreet = !isInitialDeal && gameState.phase !== GamePhase.Lobby &&
-    gameState.phase !== GamePhase.Scoring && gameState.phase !== GamePhase.Complete &&
-    gameState.phase !== GamePhase.MatchComplete;
-  const requiredPlacements = isInitialDeal ? 5 : 2;
+  const isStreet = STREET_PHASES.has(gameState.phase);
+  const requiredPlacements = isInitialDeal ? INITIAL_DEAL_COUNT : STREET_PLACE_COUNT;
 
   const [roundOverlayDismissed, setRoundOverlayDismissed] = useState(false);
   const showRoundOverlay = isRoundComplete && !isMatchComplete && !roundOverlayDismissed;
@@ -203,12 +176,11 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
           ? hand.find((c) => !newPlacedKeys.has(cardKey(c))) ?? null
           : null;
 
-        const placeCardsFn = httpsCallable(functions, 'placeCards');
-        await placeCardsFn({ roomId, placements: placementData, discard });
+        await placeCards({ roomId, placements: placementData, discard });
         trackEvent('place_cards', { roomId, street: gameState.street });
       } catch (err) {
         console.error('Failed to place cards:', err);
-        setToast('Failed to place cards');
+        showToast('Failed to place cards');
         setPlacements([]);
         setSubmitting(false);
       }
@@ -218,22 +190,20 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
   const handleLeave = async () => {
     setLeaving(true);
     try {
-      const leaveGameFn = httpsCallable(functions, 'leaveGame');
-      await leaveGameFn({ roomId });
+      await leaveGame({ roomId });
       trackEvent('leave_game', { roomId });
       onLeaveRoom();
     } catch (err) {
       console.error('Failed to leave:', err);
-      setToast('Failed to leave game');
+      showToast('Failed to leave game');
       setLeaving(false);
     }
   };
 
   const isObserver = !gameState.playerOrder.includes(uid);
   const currentPlayer = gameState.players[uid];
-  const expectedCards = gameState.street === 1 ? 5 : 3 + 2 * gameState.street;
+  const expectedCards = expectedCardsForStreet(gameState.street);
 
-  // Compute card sizes from measured sections
   const numOpponents = gameState.playerOrder.filter((id) => id !== uid).length;
   const opponentLayout = computeOpponentGridLayout(opponentSize.w, opponentSize.h, numOpponents);
   const playerCardW = computePlayerCardWidth(playerSize.w, playerSize.h);
@@ -281,7 +251,6 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
 
         {/* Bottom half: player board + hand */}
         <div ref={playerRef} className="h-1/2 flex flex-col">
-          {/* Player board — centered in remaining space */}
           <div className="flex-1 min-h-0 flex items-center justify-center" data-testid="my-board">
             {currentPlayer && playerCardW > 0 && (
               <PlayerBoard
@@ -293,10 +262,7 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
                 hasCardSelected={selectedIndex !== null && !submitting}
                 cardWidthPx={playerCardW}
                 score={currentPlayer.score}
-                hasPlaced={(() => {
-                  const b = mergedBoard;
-                  return b.top.length + b.middle.length + b.bottom.length >= expectedCards;
-                })()}
+                hasPlaced={boardCardCount(mergedBoard) >= expectedCards}
               />
             )}
           </div>
@@ -333,12 +299,7 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
         />
       )}
 
-      {/* Toast */}
-      {toast && (
-        <div className="fixed top-2 left-1/2 -translate-x-1/2 bg-red-900 border border-red-700 px-3 py-1.5 text-[10px] text-red-300 shadow-lg z-50 rounded">
-          {toast}
-        </div>
-      )}
+      <Toast message={toast} />
     </div>
     </div>
   );

--- a/frontend/src/components/mobile/MobileHandArea.tsx
+++ b/frontend/src/components/mobile/MobileHandArea.tsx
@@ -1,15 +1,9 @@
-import type { Card, Row, GameState } from '@shared/core/types';
+import type { Card, GameState } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
+import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT } from '@shared/core/constants';
 import { CardComponent, CARD_ASPECT } from '../CardComponent.tsx';
-
-interface Placement {
-  card: Card;
-  row: Row;
-}
-
-function cardKey(c: Card): string {
-  return `${c.rank}-${c.suit}`;
-}
+import { cardKey, boardCardCount } from '../../utils/card-utils.ts';
+import type { Placement } from '../../utils/card-utils.ts';
 
 interface MobileHandAreaProps {
   hand: Card[];
@@ -27,16 +21,14 @@ export function MobileHandArea({
   placements, submitting, cardWidthPx,
 }: MobileHandAreaProps) {
   const isInitialDeal = gameState.phase === GamePhase.InitialDeal;
-  const requiredPlacements = isInitialDeal ? 5 : 2;
+  const requiredPlacements = isInitialDeal ? INITIAL_DEAL_COUNT : STREET_PLACE_COUNT;
   const placedCardKeys = new Set(placements.map((p) => cardKey(p.card)));
   const remainingHand = hand.filter((c) => !placedCardKeys.has(cardKey(c)));
 
   const player = gameState.players[uid];
-  const alreadyPlaced = player
-    ? player.board.top.length + player.board.middle.length + player.board.bottom.length
-    : 0;
+  const alreadyPlaced = player ? boardCardCount(player.board) : 0;
   const waitingForOthers = isInitialDeal
-    ? alreadyPlaced >= 5 && hand.length === 0
+    ? alreadyPlaced >= INITIAL_DEAL_COUNT && hand.length === 0
     : alreadyPlaced > 0 && hand.length === 0;
 
   const handleCardClick = (index: number) => {

--- a/frontend/src/components/mobile/MobileOpponentGrid.tsx
+++ b/frontend/src/components/mobile/MobileOpponentGrid.tsx
@@ -1,5 +1,6 @@
 import type { GameState } from '@shared/core/types';
 import { PlayerBoard } from '../PlayerBoard.tsx';
+import { boardCardCount, expectedCardsForStreet } from '../../utils/card-utils.ts';
 
 interface MobileOpponentGridProps {
   gameState: GameState;
@@ -10,7 +11,7 @@ interface MobileOpponentGridProps {
 
 export function MobileOpponentGrid({ gameState, currentUid, cardWidthPx, cols }: MobileOpponentGridProps) {
   const otherPlayers = gameState.playerOrder.filter((uid) => uid !== currentUid);
-  const expectedCards = gameState.street === 1 ? 5 : 3 + 2 * gameState.street;
+  const expectedCards = expectedCardsForStreet(gameState.street);
 
   const observers = Object.values(gameState.players).filter(
     (p) => !gameState.playerOrder.includes(p.uid)
@@ -40,7 +41,6 @@ export function MobileOpponentGrid({ gameState, currentUid, cardWidthPx, cols }:
           {otherPlayers.map((uid) => {
             const player = gameState.players[uid];
             if (!player) return null;
-            const boardCount = player.board.top.length + player.board.middle.length + player.board.bottom.length;
             return (
               <PlayerBoard
                 key={uid}
@@ -49,7 +49,7 @@ export function MobileOpponentGrid({ gameState, currentUid, cardWidthPx, cols }:
                 fouled={player.fouled}
                 cardWidthPx={cardWidthPx}
                 score={player.score}
-                hasPlaced={boardCount >= expectedCards}
+                hasPlaced={boardCardCount(player.board) >= expectedCards}
                 disconnected={player.disconnected}
               />
             );

--- a/frontend/src/components/mobile/MobileRoundOverlay.tsx
+++ b/frontend/src/components/mobile/MobileRoundOverlay.tsx
@@ -1,21 +1,11 @@
 import type { GameState } from '@shared/core/types';
-import { scorePairwise } from '@shared/game-logic/scoring';
+import { formatScore } from '../../utils/scoring-display.ts';
+import { PairwiseBreakdown } from '../PairwiseBreakdown.tsx';
 
 interface MobileRoundOverlayProps {
   gameState: GameState;
   currentUid: string;
   onClose?: () => void;
-}
-
-function formatScore(n: number): string {
-  return n >= 0 ? `+${n}` : `${n}`;
-}
-
-function pairwiseLabel(rowPoints: number, scoopBonus: number, total: number, aFouled: boolean, bFouled: boolean): string {
-  if (aFouled && bFouled) return `both fouled = ${formatScore(total)}`;
-  if (aFouled || bFouled) return `foul = ${formatScore(total)}`;
-  if (scoopBonus !== 0) return `rows ${formatScore(rowPoints)} scoop ${formatScore(scoopBonus)} = ${formatScore(total)}`;
-  return `rows ${formatScore(rowPoints)} = ${formatScore(total)}`;
 }
 
 export function MobileRoundOverlay({ gameState, currentUid, onClose }: MobileRoundOverlayProps) {
@@ -66,29 +56,9 @@ export function MobileRoundOverlay({ gameState, currentUid, onClose }: MobileRou
       </div>
 
       {/* Pairwise breakdown */}
-      {players.length >= 2 && (
-        <div className="w-full max-w-sm text-xs text-gray-500 border-t border-gray-800 pt-3 mb-6">
-          <div className="font-bold text-gray-400 mb-2">Pairwise</div>
-          {players.map((pA, i) =>
-            players.slice(i + 1).map((pB) => {
-              const aFouled = roundResults[pA.uid]?.fouled ?? false;
-              const bFouled = roundResults[pB.uid]?.fouled ?? false;
-              const result = scorePairwise(
-                pA.uid, aFouled, pA.board,
-                pB.uid, bFouled, pB.board,
-              );
-              return (
-                <div key={`${pA.uid}-${pB.uid}`} className="flex justify-between gap-2 mb-1">
-                  <span className="text-gray-400 truncate">{pA.displayName} vs {pB.displayName}</span>
-                  <span className="whitespace-nowrap">
-                    {pairwiseLabel(result.rowPoints, result.scoopBonus, result.total, aFouled, bFouled)}
-                  </span>
-                </div>
-              );
-            })
-          )}
-        </div>
-      )}
+      <div className="w-full max-w-sm mb-6">
+        <PairwiseBreakdown players={players} roundResults={roundResults} />
+      </div>
 
       {onClose ? (
         <button

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,13 @@
+import { useState, useEffect } from 'react';
+
+export function useToast() {
+  const [message, setMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!message) return;
+    const t = setTimeout(() => setMessage(null), 3000);
+    return () => clearTimeout(t);
+  }, [message]);
+
+  return { message, showToast: setMessage };
+}

--- a/frontend/src/utils/card-utils.ts
+++ b/frontend/src/utils/card-utils.ts
@@ -1,0 +1,21 @@
+import type { Card, Row, Board } from '@shared/core/types';
+import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT } from '@shared/core/constants';
+
+export interface Placement {
+  card: Card;
+  row: Row;
+}
+
+export function cardKey(c: Card): string {
+  return `${c.rank}-${c.suit}`;
+}
+
+export function boardCardCount(board: Board): number {
+  return board.top.length + board.middle.length + board.bottom.length;
+}
+
+/** Total cards expected on the board after the given street. */
+export function expectedCardsForStreet(street: number): number {
+  if (street === 1) return INITIAL_DEAL_COUNT;
+  return INITIAL_DEAL_COUNT + STREET_PLACE_COUNT * (street - 1);
+}

--- a/frontend/src/utils/scoring-display.ts
+++ b/frontend/src/utils/scoring-display.ts
@@ -1,0 +1,17 @@
+export function formatScore(n: number): string {
+  return n >= 0 ? `+${n}` : `${n}`;
+}
+
+export function pairwiseLabel(
+  rowPoints: number,
+  scoopBonus: number,
+  total: number,
+  aFouled: boolean,
+  bFouled: boolean,
+): string {
+  if (aFouled && bFouled) return `both fouled = ${formatScore(total)}`;
+  if (aFouled || bFouled) return `foul = ${formatScore(total)}`;
+  if (scoopBonus !== 0)
+    return `rows ${formatScore(rowPoints)} scoop ${formatScore(scoopBonus)} = ${formatScore(total)}`;
+  return `rows ${formatScore(rowPoints)} = ${formatScore(total)}`;
+}


### PR DESCRIPTION
## Summary
- Remove dead `CardSize` preset system (xs/sm/md/lg) — only pixel-based sizing was in use, eliminating dual code paths in `CardComponent` and `PlayerBoard`
- Remove dead props (`faceDown`, `isBot`, `isObserver`) never passed by any caller
- Extract shared utilities: `cardKey`, `boardCardCount`, `expectedCardsForStreet`, `formatScore`, `pairwiseLabel`, `Placement` type
- Extract `PairwiseBreakdown` component (was duplicated across both overlay components)
- Extract `api.ts` with pre-bound Cloud Function callables (replaces ~10 inline `httpsCallable()` calls)
- Extract `useToast` hook + `Toast` component (replaces 3x duplicated toast pattern)
- Replace magic numbers with shared constants (`INITIAL_DEAL_COUNT`, `STREET_PLACE_COUNT`)
- Fix fragile phase check (negation of all non-street phases → positive `STREET_PHASES` Set)
- Fix `Row` string casts (`'top' as Row` → `Row.Top`)

Net: **-112 lines** (228 added, 340 removed), 6 new focused utility files

## Test plan
- [x] Frontend builds cleanly (`npm run build`)
- [x] Lint passes (`npm run lint -w frontend`)
- [x] Unit tests pass (`npm run test:unit`)
- [x] All 6 E2E tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)