### PR TITLE
Simplify round overlay and fix preview mock

### DIFF
--- a/BRAINSTORM.md
+++ b/BRAINSTORM.md
@@ -1,0 +1,63 @@
+# Brainstorm
+
+Ideas and future directions for Pineapple Poker.
+
+## Sound & Haptics
+
+- Card interaction sounds: tap to select, place on row, discard
+- Tile/chip sounds on score tallying
+- Subtle haptic feedback on mobile (if PWA supports it)
+
+## Animations & Visual Polish
+
+### Between-Rounds Score Screen
+- Slot machine mechanic for revealing scores — numbers spin/roll into place
+- Build suspense before showing final round delta
+- More detail on this concept exists elsewhere (TODO: link or inline)
+
+### End-of-Match Screen
+- Same slot machine energy but bigger/more dramatic
+- Cumulative score reveal with fanfare
+
+### Royalties (Visual)
+- Visual indicator when a player hits a royalty hand (flush, full house, quads, etc.)
+- Glow, shimmer, or badge on the row that qualifies
+- Ties into scoring once royalty rules are implemented
+
+### Opponent Interaction Visualization
+- "Sending troops" concept: when pairwise comparisons happen, animate something flowing between player boards (arrows, chips, sparks?)
+- Makes the head-to-head scoring feel visceral instead of just numbers
+
+### Opponent Sorting & Ranking
+- Sort opponent boards by current standing (leader at top/left)
+- Crown or highlight for the player in first place
+- Maybe podium-style layout on score screens
+
+## Gameplay Features
+
+### Royalties (Rules)
+- Implement royalty scoring bonuses (e.g., flush in top = X points)
+- Need to decide on which royalty table to use (American vs Fantasy variant)
+
+## Release & Growth
+
+### Scale-Up Testing
+- Load test with many concurrent rooms
+- Stress test dealer with 6-player games across multiple rooms
+- Measure Firestore read/write costs at scale
+
+### Marketing Strategy
+- Target poker communities, OFC fans
+- Short-form video demos (the UI is visually distinctive)
+- Beta invite / waitlist?
+
+### Mobile Releases
+- Explore PWA install prompt (already mobile-first)
+- Native wrapper (Capacitor / TWA) for App Store / Play Store?
+- Push notifications for "your turn" or "friend started a game"
+
+### Monetization
+- Cosmetics (card backs, board themes, avatars)?
+- Premium features (longer match history, stats dashboard)?
+- Tournament mode (entry fee / prize pool — legal considerations)
+- Ad-supported free tier?

--- a/e2e/bot.spec.ts
+++ b/e2e/bot.spec.ts
@@ -85,8 +85,8 @@ async function playRound(page: Page) {
   }
 
   console.log(`[${BOT_NAME}] Round complete!`);
-  await page.waitForTimeout(3_000);
-  await roundResults.getByTestId('close-results').click();
+  // Overlay auto-dismisses when next round starts
+  await roundResults.waitFor({ state: 'hidden', timeout: 15_000 });
   return 'round_complete';
 }
 

--- a/e2e/happy-path.spec.ts
+++ b/e2e/happy-path.spec.ts
@@ -22,11 +22,7 @@ test('two players play a full 3-round match', async ({ browser }) => {
       // Verify round results header
       await expect(alice.getByTestId('round-results')).toContainText(`Round ${round} of 3 Complete`);
 
-      // Close results
-      await alice.getByTestId('close-results').click();
-      await bob.getByTestId('close-results').click();
-
-      // Wait for next round to start (auto-reset -> auto-start)
+      // Wait for overlay to auto-dismiss when next round starts
     } else {
       // After round 3: match-results modal
       await alice.getByTestId('match-results').waitFor({ timeout: T_JOIN });

--- a/e2e/leave-game.spec.ts
+++ b/e2e/leave-game.spec.ts
@@ -35,10 +35,7 @@ test('player can leave mid-match and game continues for remaining player', async
   await expect(alice.getByTestId('round-results')).toContainText('Round 1 of 3 Complete');
   await expect(alice.getByTestId('round-results')).toContainText('Alice');
 
-  // Close results
-  await alice.getByTestId('close-results').click();
-
-  // After reset, Alice is in Lobby with only 1 player
+  // Overlay auto-dismisses when next phase starts; wait for lobby
   await alice.getByTestId('start-match-button').waitFor({ timeout: T_PHASE });
 
   await cleanup();

--- a/e2e/observer.spec.ts
+++ b/e2e/observer.spec.ts
@@ -35,8 +35,7 @@ test('late joiner observes match then plays after play-again', async ({ browser 
       // Inter-round results
       await alice.getByTestId('round-results').waitFor({ timeout: T_JOIN });
       await bob.getByTestId('round-results').waitFor({ timeout: T_JOIN });
-      await alice.getByTestId('close-results').click();
-      await bob.getByTestId('close-results').click();
+      // Overlay auto-dismisses when next round starts
     }
   }
 
@@ -75,10 +74,6 @@ test('late joiner observes match then plays after play-again', async ({ browser 
   await expect(alice.getByTestId('round-results')).toContainText('Alice');
   await expect(alice.getByTestId('round-results')).toContainText('Bob');
   await expect(alice.getByTestId('round-results')).toContainText('Carol');
-
-  // Pairwise section should include "vs" for 3-player pairings
-  await expect(alice.getByTestId('round-results')).toContainText('Pairwise');
-  await expect(alice.getByTestId('round-results')).toContainText('vs');
 
   await ctx3.close();
   await cleanupAB();

--- a/e2e/scoring.spec.ts
+++ b/e2e/scoring.spec.ts
@@ -20,18 +20,11 @@ test('scores are computed correctly after a full round', async ({ browser }) => 
   const aliceResults = alice.getByTestId('round-results');
   await expect(aliceResults).toContainText('Round 1 of 3 Complete');
 
-  // Pairwise section should exist
-  await expect(aliceResults).toContainText('Pairwise');
-  await expect(aliceResults).toContainText('vs');
-
   // Scores should be displayed (signed numbers)
   const resultsText = await aliceResults.textContent();
   expect(resultsText).toMatch(/[+-]\d+/);
 
-  // Close results
-  await alice.getByTestId('close-results').click();
-  await bob.getByTestId('close-results').click();
-
+  // Overlay auto-dismisses when next round starts
   // --- Round 2: both play normally ---
   await playFullRound(alice, bob);
 

--- a/e2e/sit-out.spec.ts
+++ b/e2e/sit-out.spec.ts
@@ -44,10 +44,7 @@ test('timed-out player gets auto-placed and is active in next round', async ({ b
   // Verify round results show up with round info
   await expect(alice.getByTestId('round-results')).toContainText('Round 1 of 3 Complete');
 
-  // Close results
-  await alice.getByTestId('close-results').click();
-  await bob.getByTestId('close-results').click();
-
+  // Overlay auto-dismisses when next round starts
   // --- Round 2: Bob should be ACTIVE (not sitting out), both play ---
   await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: T_PHASE });
   await expect(bob.getByTestId('phase-label')).toContainText('initial_deal', { timeout: T_PHASE });

--- a/e2e/stress.spec.ts
+++ b/e2e/stress.spec.ts
@@ -165,11 +165,12 @@ async function playRoundWithGroup(players: Player[]): Promise<{
   return { active, observers };
 }
 
-/** Wait for round results to appear and close them */
+/** Wait for round results to appear and auto-dismiss */
 async function waitAndCloseResults(player: Player) {
   await player.page.getByTestId('round-results').waitFor({ timeout: 30_000 });
   await expect(player.page.getByTestId('round-results')).toContainText('Round Complete');
-  await player.page.getByTestId('close-results').click();
+  // Overlay auto-dismisses when next round starts
+  await player.page.getByTestId('round-results').waitFor({ state: 'hidden', timeout: 30_000 });
 }
 
 function log(msg: string) {

--- a/frontend/src/components/mobile/MobileGamePage.tsx
+++ b/frontend/src/components/mobile/MobileGamePage.tsx
@@ -115,8 +115,7 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
   const isStreet = STREET_PHASES.has(gameState.phase);
   const requiredPlacements = isInitialDeal ? INITIAL_DEAL_COUNT : STREET_PLACE_COUNT;
 
-  const [roundOverlayDismissed, setRoundOverlayDismissed] = useState(false);
-  const showRoundOverlay = isRoundComplete && !isMatchComplete && !roundOverlayDismissed;
+  const showRoundOverlay = isRoundComplete && !isMatchComplete;
 
   // Reset placement state when phase changes
   const [prevPhase, setPrevPhase] = useState(gameState.phase);
@@ -125,7 +124,6 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
     setPlacements([]);
     setSelectedIndex(null);
     setSubmitting(false);
-    setRoundOverlayDismissed(false);
   }
 
   const placedCardKeys = new Set(placements.map((p) => cardKey(p.card)));
@@ -283,7 +281,6 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
         <MobileRoundOverlay
           gameState={gameState}
           currentUid={uid}
-          onClose={() => setRoundOverlayDismissed(true)}
         />
       )}
 

--- a/frontend/src/components/mobile/MobileRoundOverlay.tsx
+++ b/frontend/src/components/mobile/MobileRoundOverlay.tsx
@@ -1,14 +1,12 @@
 import type { GameState } from '@shared/core/types';
 import { formatScore } from '../../utils/scoring-display.ts';
-import { PairwiseBreakdown } from '../PairwiseBreakdown.tsx';
 
 interface MobileRoundOverlayProps {
   gameState: GameState;
   currentUid: string;
-  onClose?: () => void;
 }
 
-export function MobileRoundOverlay({ gameState, currentUid, onClose }: MobileRoundOverlayProps) {
+export function MobileRoundOverlay({ gameState, currentUid }: MobileRoundOverlayProps) {
   const players = gameState.playerOrder.map((uid) => gameState.players[uid]).filter(Boolean);
   const roundResults = gameState.roundResults ?? {};
 
@@ -55,22 +53,7 @@ export function MobileRoundOverlay({ gameState, currentUid, onClose }: MobileRou
         </table>
       </div>
 
-      {/* Pairwise breakdown */}
-      <div className="w-full max-w-sm mb-6">
-        <PairwiseBreakdown players={players} roundResults={roundResults} />
-      </div>
-
-      {onClose ? (
-        <button
-          data-testid="close-results"
-          onClick={onClose}
-          className="px-6 py-2 bg-gray-700 hover:bg-gray-600 active:bg-gray-800 text-white text-sm rounded-lg"
-        >
-          Close
-        </button>
-      ) : (
-        <p className="text-xs text-gray-500 animate-pulse">Next round starting...</p>
-      )}
+      <p className="text-xs text-gray-500 animate-pulse">Next round starting...</p>
     </div>
   );
 }

--- a/frontend/src/preview/mocks.ts
+++ b/frontend/src/preview/mocks.ts
@@ -136,8 +136,11 @@ export function generateMockGameState(opts: MockOptions): GameState {
     const playerDeck = shuffleWithRng(createDeck(), seededRng(100 + i));
 
     // Calculate how many cards should be on board
+    // Overlays require full boards for scoring/pairwise comparison
     let boardCardCount: number;
-    if (opts.cards === 'empty') {
+    if (opts.overlay !== 'none') {
+      boardCardCount = 13;
+    } else if (opts.cards === 'empty') {
       boardCardCount = 0;
     } else if (opts.cards === 'full') {
       boardCardCount = CARDS_ON_BOARD_AFTER_STREET[opts.street] ?? 0;


### PR DESCRIPTION
## Summary
- Remove pairwise breakdown from round-complete overlay (was unreadable with many players)
- Remove Close button — overlay stays until next round starts automatically
- Fix preview page crash when overlay selected (boards need 13 cards for scoring)
- Add BRAINSTORM.md for future ideas

## Test plan
- [ ] Open `/preview?overlay=round&players=6` — no error, clean score table
- [ ] Open `/preview?overlay=match` — still has pairwise (unchanged)
- [ ] Play a real game through round complete — overlay shows, auto-dismisses on next round

🤖 Generated with [Claude Code](https://claude.com/claude-code)