### PR TITLE
Fix layout shift when placing last card

### DIFF
--- a/frontend/src/components/mobile/MobileHandArea.tsx
+++ b/frontend/src/components/mobile/MobileHandArea.tsx
@@ -80,19 +80,21 @@ export function MobileHandArea({
         )}
       </div>
 
-      {/* Instruction line */}
-      {showCards && !allPlaced && (
-        <div className="text-[10px] text-gray-500 text-center mt-1">
-          {selectedIndex !== null
-            ? 'Tap a row to place'
-            : 'Tap a card to select'}
-          {placements.length > 0 && (
-            <span className="ml-1 text-gray-600">
-              ({placements.length}/{requiredPlacements})
-            </span>
-          )}
-        </div>
-      )}
+      {/* Instruction line — always rendered to prevent layout shift */}
+      <div className="text-[10px] text-gray-500 text-center mt-1">
+        {showCards && !allPlaced ? (
+          <>
+            {selectedIndex !== null ? 'Tap a row to place' : 'Tap a card to select'}
+            {placements.length > 0 && (
+              <span className="ml-1 text-gray-600">
+                ({placements.length}/{requiredPlacements})
+              </span>
+            )}
+          </>
+        ) : (
+          '\u00a0'
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Always render the instruction line container in `MobileHandArea`, using invisible content (`\u00a0`) when not showing instructions
- Prevents the hand area from shrinking when transitioning to "Submitting..." state after placing the last card

Fixes #31

## Test plan
- [ ] Start a 2-player game, place all 5 cards during initial deal — no vertical shift when "Submitting..." appears
- [ ] During street phases, place 2nd card → auto-discard → confirm no shift
- [ ] E2E: `npm test` passes (card-placement test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)