### PR TITLE
Add admin page with Google Auth

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,3 +8,5 @@ export const startMatch = httpsCallable(functions, 'startMatch');
 export const playAgain = httpsCallable(functions, 'playAgain');
 export const addBot = httpsCallable(functions, 'addBot');
 export const removeBot = httpsCallable(functions, 'removeBot');
+export const adminDeleteRoom = httpsCallable(functions, 'adminDeleteRoom');
+export const adminKickPlayer = httpsCallable(functions, 'adminKickPlayer');

--- a/frontend/src/components/AdminPage.tsx
+++ b/frontend/src/components/AdminPage.tsx
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import { auth } from '../firebase';
+import { GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged, type User } from 'firebase/auth';
+
+const ADMIN_EMAIL = 'robertbcorey@gmail.com';
+
+export default function AdminPage() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    return onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoading(false);
+    });
+  }, []);
+
+  const handleSignIn = async () => {
+    const provider = new GoogleAuthProvider();
+    await signInWithPopup(auth, provider);
+  };
+
+  const handleSignOut = async () => {
+    await signOut(auth);
+  };
+
+  if (loading) {
+    return <div className="bg-gray-950 h-screen" />;
+  }
+
+  if (!user) {
+    return (
+      <div className="bg-gray-950 h-screen flex items-center justify-center">
+        <button
+          onClick={handleSignIn}
+          className="px-6 py-3 bg-white text-gray-900 font-semibold rounded-lg hover:bg-gray-200 transition-colors"
+        >
+          Sign in with Google
+        </button>
+      </div>
+    );
+  }
+
+  if (user.email !== ADMIN_EMAIL) {
+    return (
+      <div className="bg-gray-950 h-screen flex flex-col items-center justify-center gap-4 text-white">
+        <p>Access denied</p>
+        <button
+          onClick={handleSignOut}
+          className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600 transition-colors"
+        >
+          Sign out
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-gray-950 min-h-screen text-white p-8">
+      <div className="flex items-center justify-between mb-8">
+        <h1 className="text-2xl font-bold">Admin</h1>
+        <button
+          onClick={handleSignOut}
+          className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600 transition-colors text-sm"
+        >
+          Sign out
+        </button>
+      </div>
+      <p>Hello World</p>
+    </div>
+  );
+}

--- a/frontend/src/components/AdminPage.tsx
+++ b/frontend/src/components/AdminPage.tsx
@@ -1,8 +1,133 @@
 import { useState, useEffect } from 'react';
 import { auth } from '../firebase';
 import { GoogleAuthProvider, signInWithPopup, signOut, onAuthStateChanged, type User } from 'firebase/auth';
+import { useAllGames, type GameStateWithRoom } from '../hooks/useAllGames';
+import { adminDeleteRoom, adminKickPlayer } from '../api';
 
 const ADMIN_EMAIL = 'robertbcorey@gmail.com';
+
+function timeAgo(ts: number): string {
+  const seconds = Math.floor((Date.now() - ts) / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+function RoomRow({ game }: { game: GameStateWithRoom }) {
+  const [expanded, setExpanded] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const playerNames = Object.values(game.players).map(p => p.displayName).join(', ');
+
+  const handleDelete = async () => {
+    if (!window.confirm(`Delete room ${game.roomId}? This cannot be undone.`)) return;
+    setBusy(true);
+    try {
+      await adminDeleteRoom({ roomId: game.roomId });
+    } catch (err) {
+      alert(`Failed to delete: ${err instanceof Error ? err.message : err}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleKick = async (targetUid: string, displayName: string) => {
+    if (!window.confirm(`Kick ${displayName} from room ${game.roomId}?`)) return;
+    setBusy(true);
+    try {
+      await adminKickPlayer({ roomId: game.roomId, targetUid });
+    } catch (err) {
+      alert(`Failed to kick: ${err instanceof Error ? err.message : err}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <>
+      <tr
+        className="border-b border-gray-800 hover:bg-gray-900 cursor-pointer"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <td className="py-2 px-3 font-mono">{game.roomId}</td>
+        <td className="py-2 px-3">{game.phase}</td>
+        <td className="py-2 px-3">{Object.keys(game.players).length}</td>
+        <td className="py-2 px-3 max-w-[200px] truncate">{playerNames}</td>
+        <td className="py-2 px-3">R{game.round}/{game.totalRounds}</td>
+        <td className="py-2 px-3 text-gray-400">{timeAgo(game.updatedAt)}</td>
+        <td className="py-2 px-3">
+          <button
+            onClick={(e) => { e.stopPropagation(); handleDelete(); }}
+            disabled={busy}
+            className="px-2 py-1 bg-red-700 hover:bg-red-600 rounded text-xs disabled:opacity-50"
+          >
+            Delete
+          </button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-b border-gray-800 bg-gray-900/50">
+          <td colSpan={7} className="p-3">
+            <div className="text-sm text-gray-300 space-y-1">
+              {Object.values(game.players).map(p => (
+                <div key={p.uid} className="flex items-center gap-3">
+                  <span className="font-mono text-xs text-gray-500">{p.uid.slice(0, 8)}...</span>
+                  <span>{p.displayName}</span>
+                  {p.uid === game.hostUid && <span className="text-yellow-400 text-xs">(host)</span>}
+                  {p.isBot && <span className="text-blue-400 text-xs">(bot)</span>}
+                  {!game.playerOrder.includes(p.uid) && <span className="text-gray-500 text-xs">(observer)</span>}
+                  <span className="text-gray-500">score: {p.score}</span>
+                  <button
+                    onClick={() => handleKick(p.uid, p.displayName)}
+                    disabled={busy}
+                    className="px-2 py-0.5 bg-orange-700 hover:bg-orange-600 rounded text-xs disabled:opacity-50"
+                  >
+                    Kick
+                  </button>
+                </div>
+              ))}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function Dashboard() {
+  const { games, loading } = useAllGames();
+
+  if (loading) {
+    return <p className="text-gray-400">Loading rooms...</p>;
+  }
+
+  if (games.length === 0) {
+    return <p className="text-gray-400">No active rooms.</p>;
+  }
+
+  return (
+    <table className="w-full text-left text-sm">
+      <thead>
+        <tr className="border-b border-gray-700 text-gray-400">
+          <th className="py-2 px-3">Room</th>
+          <th className="py-2 px-3">Phase</th>
+          <th className="py-2 px-3">Players</th>
+          <th className="py-2 px-3">Names</th>
+          <th className="py-2 px-3">Round</th>
+          <th className="py-2 px-3">Updated</th>
+          <th className="py-2 px-3"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {games.map(game => (
+          <RoomRow key={game.roomId} game={game} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
 
 export default function AdminPage() {
   const [user, setUser] = useState<User | null>(null);
@@ -59,14 +184,17 @@ export default function AdminPage() {
     <div className="bg-gray-950 min-h-screen text-white p-8">
       <div className="flex items-center justify-between mb-8">
         <h1 className="text-2xl font-bold">Admin</h1>
-        <button
-          onClick={handleSignOut}
-          className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600 transition-colors text-sm"
-        >
-          Sign out
-        </button>
+        <div className="flex items-center gap-4">
+          <span className="text-gray-400 text-sm">{user.email}</span>
+          <button
+            onClick={handleSignOut}
+            className="px-4 py-2 bg-gray-700 rounded hover:bg-gray-600 transition-colors text-sm"
+          >
+            Sign out
+          </button>
+        </div>
       </div>
-      <p>Hello World</p>
+      <Dashboard />
     </div>
   );
 }

--- a/frontend/src/hooks/useAllGames.ts
+++ b/frontend/src/hooks/useAllGames.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+import { collection, onSnapshot, query, orderBy } from 'firebase/firestore';
+import { db } from '../firebase.ts';
+import type { GameState } from '@shared/core/types';
+import { parseGameState } from '@shared/core/schemas';
+
+export type GameStateWithRoom = GameState & { roomId: string };
+
+export function useAllGames() {
+  const [games, setGames] = useState<GameStateWithRoom[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const q = query(collection(db, 'games'), orderBy('updatedAt', 'desc'));
+    const unsub = onSnapshot(
+      q,
+      (snapshot) => {
+        const results: GameStateWithRoom[] = [];
+        for (const doc of snapshot.docs) {
+          try {
+            const game = parseGameState(doc.data());
+            results.push({ ...game, roomId: doc.id });
+          } catch {
+            // Skip malformed docs
+          }
+        }
+        setGames(results);
+        setLoading(false);
+      },
+      () => {
+        setLoading(false);
+      },
+    );
+    return unsub;
+  }, []);
+
+  return { games, loading };
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,11 +4,17 @@ import './index.css'
 import App from './App.tsx'
 
 const PreviewPage = lazy(() => import('./preview/PreviewPage.tsx').then(m => ({ default: m.PreviewPage })));
+const AdminPage = lazy(() => import('./components/AdminPage.tsx'));
+const isAdmin = window.location.pathname === '/admin';
 const isPreview = window.location.pathname === '/preview';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    {isPreview ? (
+    {isAdmin ? (
+      <Suspense fallback={<div className="bg-gray-950 h-screen" />}>
+        <AdminPage />
+      </Suspense>
+    ) : isPreview ? (
       <Suspense fallback={<div className="bg-gray-950 h-screen" />}>
         <PreviewPage />
       </Suspense>

--- a/functions/src/admin-actions.ts
+++ b/functions/src/admin-actions.ts
@@ -1,0 +1,74 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+import { z } from 'zod';
+import { gameDoc, handDoc, deckDoc } from '../../shared/core/firestore-paths';
+import { parseGameState } from '../../shared/core/schemas';
+import { removePlayer } from './player-actions';
+
+const ADMIN_EMAIL = 'robertbcorey@gmail.com';
+
+const db = () => admin.firestore();
+
+function requireAdmin(request: { auth?: { token?: { email?: string } } }) {
+  const email = request.auth?.token?.email;
+  if (!email || email !== ADMIN_EMAIL) {
+    throw new HttpsError('permission-denied', 'Admin access required.');
+  }
+}
+
+const AdminDeleteRoomSchema = z.object({
+  roomId: z.string().min(1),
+});
+
+const AdminKickPlayerSchema = z.object({
+  roomId: z.string().min(1),
+  targetUid: z.string().min(1),
+});
+
+export const adminDeleteRoom = onCall({ maxInstances: 10 }, async (request) => {
+  requireAdmin(request);
+
+  const parsed = AdminDeleteRoomSchema.safeParse(request.data);
+  if (!parsed.success) {
+    throw new HttpsError('invalid-argument', 'Must provide roomId.');
+  }
+  const { roomId } = parsed.data;
+
+  const gameRef = db().doc(gameDoc(roomId));
+  const snap = await gameRef.get();
+  if (!snap.exists) {
+    throw new HttpsError('not-found', 'Room not found.');
+  }
+
+  const batch = db().batch();
+
+  // Delete subcollection docs for all players
+  try {
+    const game = parseGameState(snap.data());
+    for (const uid of Object.keys(game.players)) {
+      batch.delete(db().doc(handDoc(uid, roomId)));
+      batch.delete(db().doc(deckDoc(uid, roomId)));
+    }
+  } catch {
+    // If game doc is malformed, just delete the game doc itself
+  }
+
+  batch.delete(gameRef);
+  await batch.commit();
+
+  return { success: true };
+});
+
+export const adminKickPlayer = onCall({ maxInstances: 10 }, async (request) => {
+  requireAdmin(request);
+
+  const parsed = AdminKickPlayerSchema.safeParse(request.data);
+  if (!parsed.success) {
+    throw new HttpsError('invalid-argument', 'Must provide roomId and targetUid.');
+  }
+  const { roomId, targetUid } = parsed.data;
+
+  await removePlayer(targetUid, roomId);
+
+  return { success: true };
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,3 +4,4 @@ admin.initializeApp();
 
 export { joinGame, leaveGame, placeCards, startMatch, playAgain, addBot, removeBot } from './player-actions';
 export { pruneOldGames } from './cleanup';
+export { adminDeleteRoom, adminKickPlayer } from './admin-actions';

--- a/functions/src/player-actions.ts
+++ b/functions/src/player-actions.ts
@@ -76,7 +76,7 @@ function newPlayerState(uid: string, displayName: string): PlayerState {
 
 // ---- removePlayer (inlined from former game-manager.ts) ----
 
-async function removePlayer(uid: string, roomId: string): Promise<void> {
+export async function removePlayer(uid: string, roomId: string): Promise<void> {
   const gameRef = db().doc(gameDoc(roomId));
 
   await db().runTransaction(async (tx) => {


### PR DESCRIPTION
## Summary
- New `/admin` route with lazy-loaded `AdminPage` component
- Google sign-in via popup, gated to allowlisted email
- Scaffolding for future admin tools

## Test plan
- [ ] Navigate to `/admin` — see Google sign-in button
- [ ] Sign in with non-admin Google account — see "Access denied"
- [ ] Sign in with admin account — see admin dashboard
- [ ] Confirm `/` still loads the game normally
- [ ] E2E: `npm test` passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)