### PR TITLE
Add kill-all-games to admin page

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -10,3 +10,4 @@ export const addBot = httpsCallable(functions, 'addBot');
 export const removeBot = httpsCallable(functions, 'removeBot');
 export const adminDeleteRoom = httpsCallable(functions, 'adminDeleteRoom');
 export const adminKickPlayer = httpsCallable(functions, 'adminKickPlayer');
+export const adminKillAllGames = httpsCallable(functions, 'adminKillAllGames');

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,4 +4,4 @@ admin.initializeApp();
 
 export { joinGame, leaveGame, placeCards, startMatch, playAgain, addBot, removeBot } from './player-actions';
 export { pruneOldGames } from './cleanup';
-export { adminDeleteRoom, adminKickPlayer } from './admin-actions';
+export { adminDeleteRoom, adminKickPlayer, adminKillAllGames } from './admin-actions';


### PR DESCRIPTION
## Summary
- Adds `adminKillAllGames` Cloud Function that deletes all game docs and their subcollections
- Adds a confirmation UI to the admin page where you must type "kill all" to enable the button
- Button shows the current game count and is disabled when there are no games

## Test plan
- [ ] Go to `/admin`, sign in, verify the kill-all input appears above the game table
- [ ] Verify button is disabled until you type exactly `kill all`
- [ ] Create some games, click the button, verify all games are deleted
- [ ] Verify it works with 0 games (button stays disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)