### PR TITLE
Add Pineapple Run: roguelike deckbuilder game mode

### DIFF
--- a/dealer/src/dealer.ts
+++ b/dealer/src/dealer.ts
@@ -9,6 +9,8 @@ import {
   handlePhaseTimeout,
   checkAndAdvance,
   placeSingleBotCards,
+  processCharmPicks,
+  botPickCharm,
 } from './game-engine';
 
 function isPlacementPhase(phase: string): boolean {
@@ -177,6 +179,29 @@ export class Dealer {
     if (game.phase === GP.Scoring) {
       console.log(`[Dealer] [${roomId}] Scoring round`);
       await scoreRound(this.db, roomId);
+      return;
+    }
+
+    if (game.phase === GP.CharmPick) {
+      // Auto-pick for any bots that haven't picked yet
+      const picks = game.charmPicks ?? {};
+      const botsNeedToPick = game.playerOrder.filter((uid) => {
+        const p = game.players[uid];
+        return p?.isBot && !picks[uid];
+      });
+      for (const botUid of botsNeedToPick) {
+        try {
+          await botPickCharm(this.db, roomId, botUid);
+        } catch (err) {
+          console.error(`[Dealer] [${roomId}] Bot charm pick error:`, err);
+        }
+      }
+
+      // After picks (or if all already picked), try to advance
+      const advanced = await processCharmPicks(this.db, roomId);
+      if (advanced) {
+        await maybeStartRound(this.db, roomId);
+      }
       return;
     }
 

--- a/dealer/src/game-engine.ts
+++ b/dealer/src/game-engine.ts
@@ -4,6 +4,7 @@ import type {
   Card,
   Board,
   PlayerState,
+  CharmId,
 } from '../../shared/core/types';
 import { GamePhase as GP } from '../../shared/core/types';
 import {
@@ -15,6 +16,7 @@ import {
 } from '../../shared/core/constants';
 import { createShuffledDeck, dealCards } from '../../shared/game-logic/deck';
 import { scoreAllPlayers, isFoul } from '../../shared/game-logic/scoring';
+import { applyCharmBonuses, foulShieldReduction, rollCharmOptions } from '../../shared/game-logic/charms';
 import { gameDoc, handDoc, deckDoc } from '../../shared/core/firestore-paths';
 import { emptyBoard, phaseForStreet } from '../../shared/game-logic/board-utils';
 import { parseGameState, parseDeckDoc } from '../../shared/core/schemas';
@@ -227,11 +229,39 @@ export async function scoreRound(db: Firestore, roomId: string): Promise<void> {
 
     const result = scoreAllPlayers(boards, fouls);
 
+    // ---- Apply run-mode adjustments: foul shield + charm bonuses ----
+    const opponentCount = Math.max(0, game.playerOrder.length - 1);
+    const charmBonuses: Record<string, number> = {};
+    const adjustedNetScores: Record<string, number> = {};
+
+    for (const ps of result.players) {
+      let net = ps.netScore;
+      let charmBonus = 0;
+      const ownedCharms: CharmId[] | undefined = game.charms?.[ps.uid];
+
+      if (game.runMode) {
+        if (ps.fouled) {
+          // Foul shield: refund some of the foul penalty (per opponent)
+          const shield = foulShieldReduction(ownedCharms);
+          if (shield > 0) {
+            net += shield * opponentCount; // each opponent caused -FOUL_PENALTY; refund `shield` of it
+          }
+        } else {
+          const board = game.players[ps.uid]?.board;
+          if (board) charmBonus = applyCharmBonuses(ownedCharms, board);
+          net += charmBonus;
+        }
+      }
+
+      charmBonuses[ps.uid] = charmBonus;
+      adjustedNetScores[ps.uid] = net;
+    }
+
     // Build results map and accumulate scores
     const roundResults: Record<string, { netScore: number; fouled: boolean }> = {};
     for (const ps of result.players) {
       roundResults[ps.uid] = {
-        netScore: ps.netScore,
+        netScore: adjustedNetScores[ps.uid],
         fouled: ps.fouled,
       };
     }
@@ -253,13 +283,141 @@ export async function scoreRound(db: Firestore, roomId: string): Promise<void> {
 
     const isFinalRound = game.round >= game.totalRounds;
 
+    // ---- Phase transition: in run mode, go to CharmPick between rounds ----
+    if (game.runMode && !isFinalRound) {
+      // Roll 3 charm options. Players will pick from the same shared options.
+      // Exclude charms ANY player already owns to keep variety.
+      const allOwned = new Set<CharmId>();
+      if (game.charms) {
+        for (const ids of Object.values(game.charms)) {
+          for (const id of ids) allOwned.add(id);
+        }
+      }
+      const charmOptions = rollCharmOptions(3, allOwned);
+
+      tx.update(gameRef, {
+        phase: GP.CharmPick,
+        roundResults,
+        players: updatedPlayers,
+        charmBonuses,
+        charmOptions,
+        charmPicks: {},
+        phaseDeadline: null, // no timer — wait for both picks
+        updatedAt: Date.now(),
+      });
+      return;
+    }
+
     tx.update(gameRef, {
       phase: isFinalRound ? GP.MatchComplete : GP.Complete,
       roundResults,
       players: updatedPlayers,
+      charmBonuses: game.runMode ? charmBonuses : FieldValue.delete(),
       phaseDeadline: isFinalRound ? null : Date.now() + game.settings.interRoundDelayMs,
       updatedAt: Date.now(),
     });
+  });
+}
+
+/**
+ * Auto-pick a charm for a bot. Picks a random option from the available ones.
+ */
+export async function botPickCharm(db: Firestore, roomId: string, botUid: string): Promise<boolean> {
+  const gameRef = db.doc(gameDoc(roomId));
+
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(gameRef);
+    if (!snap.exists) return false;
+
+    const game = parseGameState(snap.data());
+    if (game.phase !== GP.CharmPick) return false;
+    if (!game.runMode) return false;
+
+    const options = game.charmOptions ?? [];
+    if (options.length === 0) return false;
+
+    const player = game.players[botUid];
+    if (!player?.isBot) return false;
+
+    const picks = { ...(game.charmPicks ?? {}) };
+    if (picks[botUid]) return false; // already picked
+
+    picks[botUid] = options[Math.floor(Math.random() * options.length)];
+
+    tx.update(gameRef, {
+      charmPicks: picks,
+      updatedAt: Date.now(),
+    });
+    return true;
+  });
+}
+
+/**
+ * After all active players have picked a charm, apply picks and advance to
+ * the next round (Lobby → InitialDeal via maybeStartRound).
+ */
+export async function processCharmPicks(db: Firestore, roomId: string): Promise<boolean> {
+  const gameRef = db.doc(gameDoc(roomId));
+
+  return db.runTransaction(async (tx) => {
+    const snap = await tx.get(gameRef);
+    if (!snap.exists) return false;
+
+    const game = parseGameState(snap.data());
+    if (game.phase !== GP.CharmPick) return false;
+    if (!game.runMode) return false;
+
+    // Wait until ALL active players have picked (bots are picked by botPickCharm)
+    const picks = game.charmPicks ?? {};
+    const allPicked = game.playerOrder.every((uid) => picks[uid] != null);
+    if (!allPicked) return false;
+
+    // Apply picks → add charm to each player's owned charm list
+    const charms: Record<string, CharmId[]> = { ...(game.charms ?? {}) };
+    for (const uid of game.playerOrder) {
+      const picked = picks[uid];
+      if (!picked) continue;
+      const owned = charms[uid] ? [...charms[uid]] : [];
+      owned.push(picked);
+      charms[uid] = owned;
+    }
+
+    // Reset boards/hands for next round (mirrors resetForNextRound logic)
+    const updatedPlayers: Record<string, PlayerState> = {};
+    for (const uid of game.playerOrder) {
+      updatedPlayers[uid] = {
+        ...game.players[uid],
+        board: emptyBoard(),
+        currentHand: [],
+        fouled: false,
+      };
+    }
+    for (const uid of Object.keys(game.players)) {
+      if (!game.playerOrder.includes(uid)) {
+        updatedPlayers[uid] = {
+          ...game.players[uid],
+          board: emptyBoard(),
+          currentHand: [],
+          fouled: false,
+        };
+      }
+    }
+
+    tx.update(gameRef, {
+      phase: GP.Lobby,
+      street: 0,
+      players: updatedPlayers,
+      round: game.round + 1,
+      charms,
+      charmOptions: null,
+      charmPicks: FieldValue.delete(),
+      charmBonuses: FieldValue.delete(),
+      roundResults: FieldValue.delete(),
+      phaseDeadline: null,
+      updatedAt: Date.now(),
+    });
+
+    return true;
   });
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { usePlayerHand } from './hooks/usePlayerHand.ts';
 import { RoomSelector } from './components/RoomSelector.tsx';
 import { Lobby } from './components/Lobby.tsx';
 import { MobileGamePage } from './components/mobile/MobileGamePage.tsx';
+import { CharmPickPage } from './components/CharmPickPage.tsx';
 import { GamePhase } from '@shared/core/types';
 
 class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
@@ -120,6 +121,17 @@ function App() {
         isInGame={!!isInGame}
         roomId={roomId}
         onLeaveRoom={handleLeaveRoom}
+      />
+    );
+  }
+
+  // Roguelike charm-pick screen between rounds
+  if (gameState?.phase === GamePhase.CharmPick) {
+    return (
+      <CharmPickPage
+        gameState={gameState}
+        uid={user.uid}
+        roomId={roomId}
       />
     );
   }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,6 +8,7 @@ export const startMatch = httpsCallable(functions, 'startMatch');
 export const playAgain = httpsCallable(functions, 'playAgain');
 export const addBot = httpsCallable(functions, 'addBot');
 export const removeBot = httpsCallable(functions, 'removeBot');
+export const pickCharm = httpsCallable(functions, 'pickCharm');
 export const adminDeleteRoom = httpsCallable(functions, 'adminDeleteRoom');
 export const adminKickPlayer = httpsCallable(functions, 'adminKickPlayer');
 export const adminKillAllGames = httpsCallable(functions, 'adminKillAllGames');

--- a/frontend/src/components/CharmPickPage.tsx
+++ b/frontend/src/components/CharmPickPage.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react';
+import type { GameState } from '@shared/core/types';
+import { CHARMS } from '@shared/game-logic/charms';
+import { pickCharm } from '../api.ts';
+import { useToast } from '../hooks/useToast.ts';
+import { Toast } from './Toast.tsx';
+
+interface CharmPickPageProps {
+  gameState: GameState;
+  uid: string;
+  roomId: string;
+}
+
+export function CharmPickPage({ gameState, uid, roomId }: CharmPickPageProps) {
+  const [picking, setPicking] = useState(false);
+  const { message: toast, showToast } = useToast();
+
+  const options = gameState.charmOptions ?? [];
+  const myPick = gameState.charmPicks?.[uid];
+  const myCharms = gameState.charms?.[uid] ?? [];
+  const isObserver = !gameState.playerOrder.includes(uid);
+
+  const players = gameState.playerOrder
+    .map((u) => gameState.players[u])
+    .filter(Boolean);
+
+  const handlePick = async (charmId: string) => {
+    if (picking || myPick) return;
+    setPicking(true);
+    try {
+      await pickCharm({ roomId, charmId });
+    } catch (err) {
+      console.error('Pick charm failed:', err);
+      showToast('Failed to pick charm — try again');
+    } finally {
+      setPicking(false);
+    }
+  };
+
+  const lastResults = gameState.roundResults ?? {};
+  const charmBonuses = gameState.charmBonuses ?? {};
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white font-mono flex flex-col items-center px-3 py-4">
+      <div className="w-full max-w-md">
+        <div className="text-center mb-3">
+          <div className="text-purple-300 text-xs tracking-widest uppercase">
+            Pineapple Run
+          </div>
+          <div className="text-2xl font-bold mt-1">
+            Round {gameState.round} Complete
+          </div>
+          <div className="text-gray-400 text-xs mt-1">
+            Pick a charm. {gameState.totalRounds - gameState.round} round
+            {gameState.totalRounds - gameState.round === 1 ? '' : 's'} remaining.
+          </div>
+        </div>
+
+        {/* Last round summary */}
+        <div className="border border-gray-700 p-3 mb-4 text-xs">
+          <div className="text-gray-500 mb-2 uppercase tracking-wide text-[10px]">
+            Last Round
+          </div>
+          {players.map((p) => {
+            const r = lastResults[p.uid];
+            const cb = charmBonuses[p.uid] ?? 0;
+            const net = r?.netScore ?? 0;
+            const fouled = r?.fouled;
+            return (
+              <div key={p.uid} className="flex items-center justify-between py-1">
+                <span className="text-gray-300">
+                  {p.displayName}
+                  {p.uid === uid && ' (you)'}
+                </span>
+                <div className="flex items-center gap-2">
+                  {fouled && <span className="text-red-400 text-[10px]">FOUL</span>}
+                  {cb > 0 && (
+                    <span className="text-purple-300 text-[10px]">
+                      +{cb} charms
+                    </span>
+                  )}
+                  <span
+                    className={`font-bold ${
+                      net > 0
+                        ? 'text-green-400'
+                        : net < 0
+                          ? 'text-red-400'
+                          : 'text-gray-400'
+                    }`}
+                  >
+                    {net > 0 ? '+' : ''}
+                    {net}
+                  </span>
+                  <span className="text-gray-500 text-[10px]">
+                    (total {p.score})
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Your charms */}
+        {myCharms.length > 0 && (
+          <div className="mb-4">
+            <div className="text-gray-500 text-[10px] uppercase tracking-wide mb-1">
+              Your Charms
+            </div>
+            <div className="flex flex-wrap gap-1">
+              {myCharms.map((cid, i) => {
+                const c = CHARMS[cid];
+                if (!c) return null;
+                return (
+                  <span
+                    key={i}
+                    title={c.description}
+                    className="border border-purple-700 bg-purple-900/30 text-[10px] px-1.5 py-0.5 rounded"
+                  >
+                    {c.emoji} {c.name}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Charm options */}
+        {!isObserver && (
+          <div className="space-y-2">
+            <div className="text-gray-500 text-[10px] uppercase tracking-wide mb-1">
+              {myPick ? 'You picked' : 'Pick one'}
+            </div>
+            {options.map((cid) => {
+              const c = CHARMS[cid];
+              if (!c) return null;
+              const isMine = myPick === cid;
+              const someoneElsePicked = !isMine && myPick != null;
+              return (
+                <button
+                  key={cid}
+                  onClick={() => handlePick(cid)}
+                  disabled={picking || !!myPick}
+                  className={`w-full text-left border p-3 transition-colors ${
+                    isMine
+                      ? 'border-purple-400 bg-purple-900/40'
+                      : someoneElsePicked
+                        ? 'border-gray-700 bg-gray-800/40 opacity-50'
+                        : 'border-gray-700 hover:border-purple-500 hover:bg-purple-900/20 active:bg-purple-900/40'
+                  }`}
+                >
+                  <div className="flex items-center gap-2 mb-1">
+                    <span className="text-2xl">{c.emoji}</span>
+                    <span className="font-bold text-sm text-purple-200">{c.name}</span>
+                    {isMine && (
+                      <span className="ml-auto text-purple-300 text-[10px]">PICKED</span>
+                    )}
+                  </div>
+                  <p className="text-xs text-gray-300 leading-snug">
+                    {c.description}
+                  </p>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Status */}
+        <div className="mt-4 text-center text-xs text-gray-500">
+          {(() => {
+            const pickCount = Object.keys(gameState.charmPicks ?? {}).length;
+            const total = gameState.playerOrder.length;
+            if (pickCount === total) return 'Starting next round...';
+            return `Waiting for picks (${pickCount}/${total})`;
+          })()}
+        </div>
+      </div>
+      <Toast message={toast} />
+    </div>
+  );
+}

--- a/frontend/src/components/Lobby.tsx
+++ b/frontend/src/components/Lobby.tsx
@@ -35,6 +35,7 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
     return DEFAULT_MATCH_SETTINGS.turnTimeoutMs;
   };
   const [turnTimeoutMs, setTurnTimeoutMs] = useState<number>(getInitialTimeout);
+  const [runMode, setRunMode] = useState<boolean>(false);
 
   const players = gameState ? Object.values(gameState.players) : [];
   const isHost = gameState?.hostUid === uid;
@@ -63,8 +64,8 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
         turnTimeoutMs,
         interRoundDelayMs: DEFAULT_MATCH_SETTINGS.interRoundDelayMs,
       };
-      await startMatch({ roomId, settings });
-      trackEvent('start_match', { roomId });
+      await startMatch({ roomId, settings, runMode });
+      trackEvent('start_match', { roomId, runMode: runMode ? 1 : 0 });
     } catch (err) {
       console.error('Failed to start match:', err);
       showToast('Failed to start match');
@@ -139,7 +140,7 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
           {/* Match settings */}
           <div className="mb-4">
             <div className="text-xs text-gray-500 mb-2">Match Settings</div>
-            <div className="flex items-center justify-between text-xs">
+            <div className="flex items-center justify-between text-xs mb-2">
               <span className="text-gray-400">Turn Timer</span>
               {isHost ? (
                 <select
@@ -159,6 +160,29 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
                 <span className="text-gray-400">{turnTimeoutMs / 1000}s</span>
               )}
             </div>
+            <div className="flex items-center justify-between text-xs">
+              <span className="text-gray-400">Game Mode</span>
+              {isHost ? (
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <span className={runMode ? 'text-purple-300' : 'text-gray-500'}>
+                    {runMode ? 'Pineapple Run' : 'Classic'}
+                  </span>
+                  <input
+                    type="checkbox"
+                    checked={runMode}
+                    onChange={(e) => setRunMode(e.target.checked)}
+                    className="w-4 h-4"
+                  />
+                </label>
+              ) : (
+                <span className="text-gray-400">Classic</span>
+              )}
+            </div>
+            {isHost && runMode && (
+              <p className="text-[10px] text-purple-400 mt-2 leading-relaxed">
+                Roguelike mode. 5 rounds. Pick a charm between each round to power up your scoring.
+              </p>
+            )}
           </div>
 
           <div className="space-y-2">

--- a/frontend/src/components/mobile/MobileGamePage.tsx
+++ b/frontend/src/components/mobile/MobileGamePage.tsx
@@ -6,6 +6,7 @@ import type { Card, Row, Board } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
 import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT } from '@shared/core/constants';
 import { isFoul } from '@shared/game-logic/scoring';
+import { CHARMS } from '@shared/game-logic/charms';
 import { placeCards, leaveGame } from '../../api.ts';
 import { trackEvent } from '../../firebase.ts';
 import { useCountdown } from '../../hooks/useCountdown.ts';
@@ -272,6 +273,30 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
           Observing — join next match
         </div>
       )}
+
+      {/* Run mode: charm strip */}
+      {gameState.runMode && (() => {
+        const myCharms = gameState.charms?.[uid] ?? [];
+        if (myCharms.length === 0) return null;
+        return (
+          <div className="bg-purple-900/30 border-b border-purple-700 px-2 py-1 flex items-center gap-1 text-[10px] flex-shrink-0 overflow-x-auto">
+            <span className="text-purple-300 uppercase tracking-wider mr-1 flex-shrink-0">Charms:</span>
+            {myCharms.map((cid, i) => {
+              const c = CHARMS[cid];
+              if (!c) return null;
+              return (
+                <span
+                  key={i}
+                  title={`${c.name}: ${c.description}`}
+                  className="flex-shrink-0"
+                >
+                  {c.emoji}
+                </span>
+              );
+            })}
+          </div>
+        );
+      })()}
 
       {/* Main content: 50/50 split */}
       <div className="flex-1 flex flex-col min-h-0">

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -2,6 +2,6 @@ import * as admin from 'firebase-admin';
 
 admin.initializeApp();
 
-export { joinGame, leaveGame, placeCards, startMatch, playAgain, addBot, removeBot } from './player-actions';
+export { joinGame, leaveGame, placeCards, startMatch, playAgain, addBot, removeBot, pickCharm } from './player-actions';
 export { pruneOldGames } from './cleanup';
 export { adminDeleteRoom, adminKickPlayer, adminKillAllGames } from './admin-actions';

--- a/functions/src/player-actions.ts
+++ b/functions/src/player-actions.ts
@@ -10,9 +10,11 @@ import {
   TOP_ROW_SIZE,
   FIVE_CARD_ROW_SIZE,
   ROUNDS_PER_MATCH,
+  ROUNDS_PER_RUN,
   MAX_PLAYERS,
   DEFAULT_MATCH_SETTINGS,
 } from '../../shared/core/constants';
+import { CHARMS } from '../../shared/game-logic/charms';
 import { gameDoc, handDoc, deckDoc } from '../../shared/core/firestore-paths';
 import { emptyBoard } from '../../shared/game-logic/board-utils';
 import { parseGameState, CardSchema, MatchSettingsSchema } from '../../shared/core/schemas';
@@ -344,6 +346,7 @@ export const placeCards = onCall({ maxInstances: 10 }, async (request) => {
 
 const StartMatchSchema = RoomIdSchema.extend({
   settings: MatchSettingsSchema.optional(),
+  runMode: z.boolean().optional(),
 });
 
 export const startMatch = onCall({ maxInstances: 10 }, async (request) => {
@@ -356,7 +359,7 @@ export const startMatch = onCall({ maxInstances: 10 }, async (request) => {
   if (!parsed.success) {
     throw new HttpsError('invalid-argument', 'Invalid request data.');
   }
-  const { roomId, settings } = parsed.data;
+  const { roomId, settings, runMode } = parsed.data;
   const gameRef = db().doc(gameDoc(roomId));
 
   await db().runTransaction(async (tx) => {
@@ -381,18 +384,80 @@ export const startMatch = onCall({ maxInstances: 10 }, async (request) => {
       throw new HttpsError('failed-precondition', 'Need at least 2 players to start.');
     }
 
-    if (settings) {
-      tx.update(gameRef, {
-        round: 1,
-        settings,
-        updatedAt: Date.now(),
-      });
-    } else {
-      tx.update(gameRef, {
-        round: 1,
-        updatedAt: Date.now(),
-      });
+    // Use `any` here because Firestore's update typing is strict about
+    // FieldValue | Partial<T>; we're constructing a heterogeneous patch.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const baseUpdate: Record<string, any> = {
+      round: 1,
+      updatedAt: Date.now(),
+    };
+    if (settings) baseUpdate.settings = settings;
+
+    if (runMode) {
+      baseUpdate.runMode = true;
+      baseUpdate.totalRounds = ROUNDS_PER_RUN;
+      // Initialise empty charm collections for each active player
+      const charms: Record<string, string[]> = {};
+      for (const u of game.playerOrder) charms[u] = [];
+      baseUpdate.charms = charms;
     }
+
+    tx.update(gameRef, baseUpdate);
+  });
+
+  return { success: true };
+});
+
+// ---- pickCharm ----
+
+const PickCharmSchema = RoomIdSchema.extend({
+  charmId: z.string().min(1),
+});
+
+export const pickCharm = onCall({ maxInstances: 10 }, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) {
+    throw new HttpsError('unauthenticated', 'Must be signed in.');
+  }
+
+  const parsed = PickCharmSchema.safeParse(request.data);
+  if (!parsed.success) {
+    throw new HttpsError('invalid-argument', 'Invalid request data.');
+  }
+  const { roomId, charmId } = parsed.data;
+
+  if (!CHARMS[charmId]) {
+    throw new HttpsError('invalid-argument', 'Unknown charm.');
+  }
+
+  const gameRef = db().doc(gameDoc(roomId));
+
+  await db().runTransaction(async (tx) => {
+    const snap = await tx.get(gameRef);
+    if (!snap.exists) throw new HttpsError('not-found', 'No game exists.');
+
+    const game = parseGameState(snap.data());
+    if (!game.runMode) throw new HttpsError('failed-precondition', 'Not in a run.');
+    if (game.phase !== GP.CharmPick) {
+      throw new HttpsError('failed-precondition', 'Not in charm pick phase.');
+    }
+    if (!game.playerOrder.includes(uid)) {
+      throw new HttpsError('failed-precondition', 'Observers cannot pick charms.');
+    }
+    if (!(game.charmOptions ?? []).includes(charmId)) {
+      throw new HttpsError('invalid-argument', 'Charm is not on offer this pick.');
+    }
+
+    const picks = { ...(game.charmPicks ?? {}) };
+    if (picks[uid]) {
+      throw new HttpsError('failed-precondition', 'You already picked this round.');
+    }
+    picks[uid] = charmId;
+
+    tx.update(gameRef, {
+      charmPicks: picks,
+      updatedAt: Date.now(),
+    });
   });
 
   return { success: true };
@@ -447,6 +512,13 @@ export const playAgain = onCall({ maxInstances: 10 }, async (request) => {
       playerOrder: updatedPlayerOrder,
       roundResults: FieldValue.delete(),
       phaseDeadline: null,
+      // Clear all run-mode state — host must opt back in via Start
+      runMode: FieldValue.delete(),
+      totalRounds: ROUNDS_PER_MATCH,
+      charms: FieldValue.delete(),
+      charmOptions: FieldValue.delete(),
+      charmPicks: FieldValue.delete(),
+      charmBonuses: FieldValue.delete(),
       updatedAt: Date.now(),
     });
   });

--- a/shared/core/constants.ts
+++ b/shared/core/constants.ts
@@ -74,6 +74,9 @@ export const TOTAL_STREETS = 5;
 /** Number of rounds per match. */
 export const ROUNDS_PER_MATCH = 3;
 
+/** Number of rounds per Pineapple Run (roguelike mode). */
+export const ROUNDS_PER_RUN = 5;
+
 /** Default match settings applied when creating a new room */
 import type { MatchSettings } from './types';
 export const DEFAULT_MATCH_SETTINGS: MatchSettings = {

--- a/shared/core/schemas.ts
+++ b/shared/core/schemas.ts
@@ -47,6 +47,7 @@ const GAME_PHASE_VALUES = [
   'street_5',
   'scoring',
   'complete',
+  'charm_pick',
   'match_complete',
 ] as const;
 
@@ -95,6 +96,12 @@ export const GameStateSchema = z.object({
   createdAt: z.number(),
   updatedAt: z.number(),
   phaseDeadline: z.number().nullable(),
+  // Run mode (optional — present only for roguelike runs)
+  runMode: z.boolean().optional(),
+  charms: z.record(z.string(), z.array(z.string())).optional(),
+  charmOptions: z.array(z.string()).nullable().optional(),
+  charmPicks: z.record(z.string(), z.string()).optional(),
+  charmBonuses: z.record(z.string(), z.number()).optional(),
 });
 
 // ---- Subcollection documents ----

--- a/shared/core/types.ts
+++ b/shared/core/types.ts
@@ -57,6 +57,7 @@ export const GamePhase = {
   Street5: 'street_5',
   Scoring: 'scoring',
   Complete: 'complete',
+  CharmPick: 'charm_pick',
   MatchComplete: 'match_complete',
 } as const;
 export type GamePhase = (typeof GamePhase)[keyof typeof GamePhase];
@@ -125,6 +126,9 @@ export interface MatchSettings {
   interRoundDelayMs: number;   // delay between rounds before auto-starting next
 }
 
+/** Charm = roguelike modifier picked between rounds in run mode. */
+export type CharmId = string;
+
 export interface GameState {
   gameId: string;
   phase: GamePhase;
@@ -132,13 +136,19 @@ export interface GameState {
   playerOrder: string[];   // uid list for turn order
   street: number;          // 1-5
   round: number;           // 1-based current round (0 = pre-match lobby)
-  totalRounds: number;     // rounds per match (always 3)
+  totalRounds: number;     // rounds per match (3 normal, 5 in run mode)
   hostUid: string;         // uid of match creator
   settings: MatchSettings; // configurable match settings
   roundResults?: Record<string, RoundResult>;
   createdAt: number;
   updatedAt: number;
   phaseDeadline: number | null;  // Unix timestamp when phase expires
+  // ---- Run mode (roguelike deckbuilder) ----
+  runMode?: boolean;
+  charms?: Record<string, CharmId[]>;        // each player's owned charms
+  charmOptions?: CharmId[] | null;           // 3 charms offered this pick (shared)
+  charmPicks?: Record<string, CharmId>;      // who picked which charm this pick
+  charmBonuses?: Record<string, number>;     // last round's charm bonus per uid
 }
 
 // ---- Scoring types ----

--- a/shared/game-logic/charms.ts
+++ b/shared/game-logic/charms.ts
@@ -1,0 +1,251 @@
+/**
+ * Charms = roguelike modifiers drafted between rounds in Pineapple Run mode.
+ *
+ * Each charm adds a flat bonus to its owner's net score during scoring,
+ * based on properties of their final board. Charms stack across rounds
+ * (cumulative — owning a charm applies its bonus every remaining round).
+ *
+ * Note: charm bonuses are added on top of pairwise scoring; they do NOT
+ * affect the opponent's score. They are pure +EV for the owner.
+ */
+import type { Board, Card, CharmId } from '../core/types';
+import { HandRank, ThreeCardHandRank, Rank } from '../core/types';
+import {
+  evaluate3CardHand,
+  evaluate5CardHand,
+} from './hand-evaluation';
+import { isFoul } from './scoring';
+
+export interface CharmDef {
+  id: CharmId;
+  name: string;
+  emoji: string;
+  description: string;
+  /** Compute bonus points for this charm given the final board (assumes non-fouled). */
+  bonus: (board: Board) => number;
+  /** Special: if true, this charm reduces foul penalty (handled separately by caller). */
+  foulShield?: number;
+}
+
+// ---- Helpers ----
+
+function isFlush(cards: Card[]): boolean {
+  if (cards.length < 2) return false;
+  return cards.every((c) => c.suit === cards[0].suit);
+}
+
+function countPairsAcrossBoard(board: Board): number {
+  // Count pairs in each row separately
+  let pairs = 0;
+  for (const row of [board.top, board.middle, board.bottom]) {
+    const counts = new Map<number, number>();
+    for (const c of row) counts.set(c.rank, (counts.get(c.rank) ?? 0) + 1);
+    for (const v of counts.values()) {
+      if (v >= 2) pairs += Math.floor(v / 2);
+    }
+  }
+  return pairs;
+}
+
+function countRankOnBoard(board: Board, rank: number): number {
+  let n = 0;
+  for (const row of [board.top, board.middle, board.bottom]) {
+    for (const c of row) if (c.rank === rank) n++;
+  }
+  return n;
+}
+
+function rowHasTrips(cards: Card[]): boolean {
+  const counts = new Map<number, number>();
+  for (const c of cards) counts.set(c.rank, (counts.get(c.rank) ?? 0) + 1);
+  for (const v of counts.values()) if (v >= 3) return true;
+  return false;
+}
+
+function topIsPairOrBetter(board: Board): boolean {
+  if (board.top.length !== 3) return false;
+  return evaluate3CardHand(board.top).handRank !== ThreeCardHandRank.HighCard;
+}
+
+function middleIsTwoPairOrBetter(board: Board): boolean {
+  if (board.middle.length !== 5) return false;
+  return evaluate5CardHand(board.middle).handRank >= HandRank.TwoPair;
+}
+
+function bottomIsStraightOrBetter(board: Board): boolean {
+  if (board.bottom.length !== 5) return false;
+  return evaluate5CardHand(board.bottom).handRank >= HandRank.Straight;
+}
+
+function rowFlushes(board: Board): number {
+  let n = 0;
+  if (board.middle.length === 5 && isFlush(board.middle)) n++;
+  if (board.bottom.length === 5 && isFlush(board.bottom)) n++;
+  return n;
+}
+
+function rowStraights(board: Board): number {
+  let n = 0;
+  if (board.middle.length === 5) {
+    const r = evaluate5CardHand(board.middle).handRank;
+    if (r === HandRank.Straight || r === HandRank.StraightFlush) n++;
+  }
+  if (board.bottom.length === 5) {
+    const r = evaluate5CardHand(board.bottom).handRank;
+    if (r === HandRank.Straight || r === HandRank.StraightFlush) n++;
+  }
+  return n;
+}
+
+/** Returns true if any row contains all four ranks: J, Q, K, A. */
+function hasRoyals(board: Board): boolean {
+  const need = [Rank.Jack, Rank.Queen, Rank.King, Rank.Ace];
+  for (const row of [board.middle, board.bottom]) {
+    if (row.length < 4) continue;
+    const ranks = new Set(row.map((c) => c.rank));
+    if (need.every((r) => ranks.has(r))) return true;
+  }
+  return false;
+}
+
+// ---- Charm catalog ----
+
+export const CHARMS: Record<CharmId, CharmDef> = {
+  sharp_suits: {
+    id: 'sharp_suits',
+    name: 'Sharp Suits',
+    emoji: '♠️',
+    description: '+4 for each row that is a flush.',
+    bonus: (b) => 4 * rowFlushes(b),
+  },
+  pair_pride: {
+    id: 'pair_pride',
+    name: 'Pair Pride',
+    emoji: '👯',
+    description: '+1 for each pair on your board.',
+    bonus: (b) => countPairsAcrossBoard(b),
+  },
+  high_roller: {
+    id: 'high_roller',
+    name: 'High Roller',
+    emoji: '🎩',
+    description: '+5 if your top row is a pair or better.',
+    bonus: (b) => (topIsPairOrBetter(b) ? 5 : 0),
+  },
+  brick_bottom: {
+    id: 'brick_bottom',
+    name: 'Brick Bottom',
+    emoji: '🧱',
+    description: '+5 if your bottom row is a straight or better.',
+    bonus: (b) => (bottomIsStraightOrBetter(b) ? 5 : 0),
+  },
+  middle_mastery: {
+    id: 'middle_mastery',
+    name: 'Middle Mastery',
+    emoji: '🎯',
+    description: '+5 if your middle row is two pair or better.',
+    bonus: (b) => (middleIsTwoPairOrBetter(b) ? 5 : 0),
+  },
+  lucky_sevens: {
+    id: 'lucky_sevens',
+    name: 'Lucky Sevens',
+    emoji: '🍀',
+    description: '+2 for each 7 on your board.',
+    bonus: (b) => 2 * countRankOnBoard(b, Rank.Seven),
+  },
+  royal_touch: {
+    id: 'royal_touch',
+    name: 'Royal Touch',
+    emoji: '👑',
+    description: '+8 if any 5-card row contains J, Q, K and A.',
+    bonus: (b) => (hasRoyals(b) ? 8 : 0),
+  },
+  threes_company: {
+    id: 'threes_company',
+    name: "Three's Company",
+    emoji: '🎲',
+    description: '+5 if any row contains three of a kind.',
+    bonus: (b) => {
+      if (rowHasTrips(b.top)) return 5;
+      if (rowHasTrips(b.middle)) return 5;
+      if (rowHasTrips(b.bottom)) return 5;
+      return 0;
+    },
+  },
+  straight_edge: {
+    id: 'straight_edge',
+    name: 'Straight Edge',
+    emoji: '📏',
+    description: '+4 for each row that is a straight or better.',
+    bonus: (b) => 4 * rowStraights(b),
+  },
+  big_score: {
+    id: 'big_score',
+    name: 'Big Score',
+    emoji: '💰',
+    description: '+3 every round, no matter what.',
+    bonus: () => 3,
+  },
+  ace_collector: {
+    id: 'ace_collector',
+    name: 'Ace Collector',
+    emoji: '🥇',
+    description: '+2 for each Ace on your board.',
+    bonus: (b) => 2 * countRankOnBoard(b, Rank.Ace),
+  },
+  foul_shield: {
+    id: 'foul_shield',
+    name: 'Foul Shield',
+    emoji: '🛡️',
+    description: 'Reduces foul penalty by 4 per opponent.',
+    bonus: () => 0,
+    foulShield: 4,
+  },
+};
+
+export const CHARM_IDS: CharmId[] = Object.keys(CHARMS);
+
+/** Pick `count` random charm ids that are NOT already in `excluded`. */
+export function rollCharmOptions(count: number, excluded: Set<CharmId>): CharmId[] {
+  const pool = CHARM_IDS.filter((id) => !excluded.has(id));
+  // If pool is too small (lots of charms already owned), allow duplicates from full set
+  const source = pool.length >= count ? pool : CHARM_IDS;
+  const out: CharmId[] = [];
+  const taken = new Set<number>();
+  while (out.length < count && taken.size < source.length) {
+    const i = Math.floor(Math.random() * source.length);
+    if (taken.has(i)) continue;
+    taken.add(i);
+    out.push(source[i]);
+  }
+  // Fallback: pad with random duplicates if we somehow can't fill
+  while (out.length < count) {
+    out.push(source[Math.floor(Math.random() * source.length)]);
+  }
+  return out;
+}
+
+/** Total bonus points from a player's owned charms applied to their final board. */
+export function applyCharmBonuses(charms: CharmId[] | undefined, board: Board): number {
+  if (!charms || charms.length === 0) return 0;
+  // Don't grant board-state bonuses to fouled players (they didn't make a valid hand).
+  if (isFoul(board)) return 0;
+  let total = 0;
+  for (const id of charms) {
+    const def = CHARMS[id];
+    if (!def) continue;
+    total += def.bonus(board);
+  }
+  return total;
+}
+
+/** Total foul-penalty reduction from a player's foul-shield charms (per opponent). */
+export function foulShieldReduction(charms: CharmId[] | undefined): number {
+  if (!charms) return 0;
+  let r = 0;
+  for (const id of charms) {
+    const def = CHARMS[id];
+    if (def?.foulShield) r += def.foulShield;
+  }
+  return r;
+}


### PR DESCRIPTION
## Summary

A new opt-in 5-round game mode where players draft a "charm" (Balatro-style modifier) between each round that adds bonus scoring for the rest of the run. Roguelike deckbuilder layered on top of the existing pineapple poker game engine.

- Same Firebase/Firestore/dealer infrastructure — no new collection or service
- Charms apply to the owner's net score during scoring (not pairwise), so they're pure +EV — they don't reduce opponent points
- Each round both players are offered the same 3 random charms; charms already owned by any player are excluded to keep variety
- 12 charms in the catalog covering flushes, pairs, top/middle/bottom row strength, ace/seven counts, foul shield, etc.
- Classic mode is unaffected — all new fields are optional and only exercised when host opts into run mode at match start

## How to play

In the lobby, host toggles "Pineapple Run" before pressing Start. Both players play a normal pineapple round, then both see a charm-pick screen between rounds. Charms stack across rounds; total score after 5 rounds wins.

## What changed

- `shared/`: new `GamePhase.CharmPick`, charm catalog (`shared/game-logic/charms.ts`), `runMode`/`charms`/`charmOptions`/`charmPicks`/`charmBonuses` fields on GameState (all optional)
- `dealer/`: `scoreRound` applies charm bonuses + foul-shield refund; routes to CharmPick (instead of Complete) between rounds in run mode; new `processCharmPicks`/`botPickCharm` functions
- `functions/`: `pickCharm` endpoint, `runMode` flag on `startMatch`, cleanup of charm fields on `playAgain`
- `frontend/`: Run Mode toggle in Lobby, `CharmPickPage` between rounds, charm strip in mobile game header showing owned charms

## Test plan

- [x] All 3 workspaces build (frontend, functions, dealer)
- [x] Existing unit tests pass (89 shared + 18 dealer)
- [x] Lint passes
- [ ] Manual: classic mode unaffected (existing flow works without runMode)
- [ ] Manual: run mode 5-round flow, charm-pick UI, charm bonuses applied to score
- [ ] CI e2e suite green

https://claude.ai/code/session_01XWDdQAa8breSmTzskgPTF6

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWDdQAa8breSmTzskgPTF6)_