### PR TITLE
Add Kites cooperative real-time game mode

### DIFF
--- a/dealer/src/index.ts
+++ b/dealer/src/index.ts
@@ -3,6 +3,7 @@ import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Dealer } from './dealer';
+import { KitesDealer } from './kites/kites-dealer';
 import { DEALER_HEALTH_PORT } from '../../shared/core/constants';
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
@@ -84,6 +85,7 @@ admin.initializeApp(IS_PRODUCTION ? undefined : { projectId: 'pineapple-poker-8f
 
 const db = admin.firestore();
 const dealer = new Dealer(db);
+const kitesDealer = new KitesDealer(db);
 
 // ── Health HTTP server ──────────────────────────────────────────────────────
 
@@ -101,6 +103,7 @@ const healthServer = http.createServer((req, res) => {
       pid: process.pid,
       uptime: Math.round((Date.now() - startTime) / 1000),
       rooms: dealer.roomCount,
+      kitesRooms: kitesDealer.roomCount,
     }));
   } else {
     res.writeHead(404);
@@ -115,6 +118,7 @@ healthServer.listen(healthPort, healthHost, () => {
 // ── Start dealer ────────────────────────────────────────────────────────────
 
 dealer.start();
+kitesDealer.start();
 console.log(`[Dealer] Running in ${IS_PRODUCTION ? 'PRODUCTION' : 'development'} mode`);
 
 // ── Graceful shutdown ───────────────────────────────────────────────────────
@@ -122,6 +126,7 @@ console.log(`[Dealer] Running in ${IS_PRODUCTION ? 'PRODUCTION' : 'development'}
 function shutdown(): void {
   console.log('\n[Dealer] Shutting down...');
   dealer.stop();
+  kitesDealer.stop();
   healthServer.close();
   if (!IS_PRODUCTION) removeLockfile();
   process.exit(0);

--- a/dealer/src/kites/kites-dealer.ts
+++ b/dealer/src/kites/kites-dealer.ts
@@ -1,0 +1,148 @@
+import type { Firestore } from 'firebase-admin/firestore';
+import type { KitesGameState } from '../../../shared/kites/types';
+import { KitesPhase } from '../../../shared/kites/types';
+import { parseKitesGameState } from '../../../shared/kites/schemas';
+import { nextTimerToExpire, cardsRemaining } from '../../../shared/kites/game-logic';
+
+interface RoomState {
+  // Timestamp the timer is currently armed for.
+  armedExpiresAt: number | null;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+/**
+ * Listens to the kitesGames collection and arms a single setTimeout per room
+ * for the soonest-expiring sand timer. When it fires, the dealer transitions
+ * the room to Lost.
+ */
+export class KitesDealer {
+  private db: Firestore;
+  private unsubscribe: (() => void) | null = null;
+  private rooms: Map<string, RoomState> = new Map();
+
+  constructor(db: Firestore) {
+    this.db = db;
+  }
+
+  get roomCount(): number { return this.rooms.size; }
+
+  start(): void {
+    console.log('[KitesDealer] Starting — listening to kitesGames collection');
+    this.unsubscribe = this.db.collection('kitesGames').onSnapshot(
+      (snap) => {
+        for (const change of snap.docChanges()) {
+          const roomId = change.doc.id;
+          if (change.type === 'removed') {
+            this.removeRoom(roomId);
+          } else {
+            this.onSnapshot(roomId, change.doc);
+          }
+        }
+      },
+      (err) => console.error('[KitesDealer] Snapshot listener error:', err),
+    );
+  }
+
+  stop(): void {
+    console.log('[KitesDealer] Stopping');
+    for (const [roomId] of this.rooms) this.removeRoom(roomId);
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+  }
+
+  private removeRoom(roomId: string): void {
+    const room = this.rooms.get(roomId);
+    if (room?.timer) clearTimeout(room.timer);
+    this.rooms.delete(roomId);
+  }
+
+  private getOrCreateRoom(roomId: string): RoomState {
+    let room = this.rooms.get(roomId);
+    if (!room) {
+      room = { armedExpiresAt: null, timer: null };
+      this.rooms.set(roomId, room);
+    }
+    return room;
+  }
+
+  private onSnapshot(roomId: string, doc: FirebaseFirestore.QueryDocumentSnapshot): void {
+    let game: KitesGameState;
+    try {
+      game = parseKitesGameState(doc.data());
+    } catch (err) {
+      console.error(`[KitesDealer] [${roomId}] Skipping unparseable doc:`, err);
+      return;
+    }
+
+    if (game.phase !== KitesPhase.Playing) {
+      this.disarmTimer(roomId);
+      return;
+    }
+
+    const next = nextTimerToExpire(game);
+    if (!next) {
+      this.disarmTimer(roomId);
+      return;
+    }
+    this.armTimer(roomId, next.expiresAt);
+  }
+
+  private disarmTimer(roomId: string): void {
+    const room = this.rooms.get(roomId);
+    if (!room) return;
+    if (room.timer) {
+      clearTimeout(room.timer);
+      room.timer = null;
+    }
+    room.armedExpiresAt = null;
+  }
+
+  private armTimer(roomId: string, expiresAt: number): void {
+    const room = this.getOrCreateRoom(roomId);
+    if (room.armedExpiresAt === expiresAt) return;
+    if (room.timer) {
+      clearTimeout(room.timer);
+      room.timer = null;
+    }
+    room.armedExpiresAt = expiresAt;
+    const delay = Math.max(0, expiresAt - Date.now());
+    console.log(`[KitesDealer] [${roomId}] Armed timer for ${Math.round(delay / 1000)}s`);
+    room.timer = setTimeout(() => {
+      room.timer = null;
+      room.armedExpiresAt = null;
+      this.onTimerExpired(roomId).catch((err) =>
+        console.error(`[KitesDealer] [${roomId}] expiry handler error:`, err),
+      );
+    }, delay);
+  }
+
+  private async onTimerExpired(roomId: string): Promise<void> {
+    const ref = this.db.doc(`kitesGames/${roomId}`);
+    await this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(ref);
+      if (!snap.exists) return;
+      const game = parseKitesGameState(snap.data());
+      if (game.phase !== KitesPhase.Playing) return;
+
+      const now = Date.now();
+      const next = nextTimerToExpire(game);
+      if (!next) return;
+      // Re-check: has the soonest-expiring timer actually expired now?
+      // (A flip we missed could have pushed it later.)
+      if (next.expiresAt > now) return;
+
+      const finalScore = cardsRemaining(game);
+      tx.update(ref, {
+        phase: KitesPhase.Lost,
+        endedAt: now,
+        endReason: 'timer_expired',
+        expiredTimerColor: next.timer.color,
+        finalScore,
+        updatedAt: now,
+      });
+      console.log(`[KitesDealer] [${roomId}] ${next.timer.color} timer expired — game lost (score=${finalScore})`);
+    });
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,6 +20,22 @@ service cloud.firestore {
       }
     }
 
+    // Kites games: same access pattern as Pineapple games
+    match /kitesGames/{gameId} {
+      allow read: if true;
+      allow write: if false;
+
+      match /hands/{uid} {
+        allow read: if request.auth != null && request.auth.uid == uid;
+        allow write: if false;
+      }
+
+      // Shared draw pile: server-only
+      match /deck/{deckId} {
+        allow read, write: if false;
+      }
+    }
+
     // Deny everything else
     match /{document=**} {
       allow read, write: if false;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { Lobby } from './components/Lobby.tsx';
 import { MobileGamePage } from './components/mobile/MobileGamePage.tsx';
 import { CharmPickPage } from './components/CharmPickPage.tsx';
 import { GamePhase } from '@shared/core/types';
+import { KitesApp } from './KitesApp.tsx';
 
 class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
   state = { error: null as Error | null };
@@ -46,6 +47,11 @@ function getRoomFromUrl(): string | null {
   return params.get('room') || null;
 }
 
+function getGameTypeFromUrl(): 'pineapple' | 'kites' {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('game') === 'kites' ? 'kites' : 'pineapple';
+}
+
 function setRoomInUrl(roomId: string | null) {
   const url = new URL(window.location.href);
   if (roomId) {
@@ -56,17 +62,45 @@ function setRoomInUrl(roomId: string | null) {
   history.replaceState(null, '', url.toString());
 }
 
+function setGameTypeInUrl(game: 'pineapple' | 'kites') {
+  const url = new URL(window.location.href);
+  if (game === 'kites') {
+    url.searchParams.set('game', 'kites');
+  } else {
+    url.searchParams.delete('game');
+  }
+  // Switching game wipes any room param to prevent cross-game lookup.
+  url.searchParams.delete('room');
+  history.replaceState(null, '', url.toString());
+}
+
 function App() {
+  const [gameType, setGameType] = useState<'pineapple' | 'kites'>(getGameTypeFromUrl);
   const { user, loading: authLoading, displayName, setDisplayName, signIn } = useAuth();
   const [roomId, setRoomId] = useState<string | null>(getRoomFromUrl);
-  const { gameState, loading: gameLoading } = useGameState(roomId);
-  const hand = usePlayerHand(user?.uid, roomId);
+  const { gameState, loading: gameLoading } = useGameState(gameType === 'pineapple' ? roomId : null);
+  const hand = usePlayerHand(user?.uid, gameType === 'pineapple' ? roomId : null);
   // Sync URL on popstate (back/forward)
   useEffect(() => {
-    const onPopState = () => setRoomId(getRoomFromUrl());
+    const onPopState = () => {
+      setRoomId(getRoomFromUrl());
+      setGameType(getGameTypeFromUrl());
+    };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
+
+  if (gameType === 'kites') {
+    return (
+      <KitesApp
+        onSwitchToPineapple={() => {
+          setGameTypeInUrl('pineapple');
+          setRoomId(null);
+          setGameType('pineapple');
+        }}
+      />
+    );
+  }
 
   const handleRoomJoined = (newRoomId: string) => {
     setRoomId(newRoomId);

--- a/frontend/src/KitesApp.tsx
+++ b/frontend/src/KitesApp.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from './hooks/useAuth.ts';
+import { useKitesGameState } from './hooks/kites/useKitesGameState.ts';
+import { useKitesHand } from './hooks/kites/useKitesHand.ts';
+import { KitesRoomSelector } from './components/kites/KitesRoomSelector.tsx';
+import { KitesLobby } from './components/kites/KitesLobby.tsx';
+import { KitesGamePage } from './components/kites/KitesGamePage.tsx';
+
+function getRoomFromUrl(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('room') || null;
+}
+
+function setRoomInUrl(roomId: string | null) {
+  const url = new URL(window.location.href);
+  if (roomId) {
+    url.searchParams.set('room', roomId);
+    url.searchParams.set('game', 'kites');
+  } else {
+    url.searchParams.delete('room');
+  }
+  history.replaceState(null, '', url.toString());
+}
+
+interface Props {
+  onSwitchToPineapple?: () => void;
+}
+
+export function KitesApp({ onSwitchToPineapple }: Props) {
+  const { user, loading: authLoading, displayName, setDisplayName, signIn } = useAuth();
+  const [roomId, setRoomId] = useState<string | null>(getRoomFromUrl);
+  const { gameState, loading: gameLoading } = useKitesGameState(roomId);
+  const hand = useKitesHand(user?.uid, roomId);
+
+  useEffect(() => {
+    const onPopState = () => setRoomId(getRoomFromUrl());
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
+
+  const handleRoomJoined = (newRoomId: string) => {
+    setRoomId(newRoomId);
+    setRoomInUrl(newRoomId);
+  };
+
+  const handleLeaveRoom = () => {
+    setRoomId(null);
+    setRoomInUrl(null);
+  };
+
+  if (authLoading) {
+    return (
+      <div className="min-h-screen bg-sky-950 text-white flex items-center justify-center">
+        <div className="text-sky-400">Loading...</div>
+      </div>
+    );
+  }
+
+  if (!roomId) {
+    return (
+      <KitesRoomSelector
+        displayName={displayName}
+        setDisplayName={setDisplayName}
+        signIn={signIn}
+        onRoomJoined={handleRoomJoined}
+        onSwitchGame={onSwitchToPineapple}
+      />
+    );
+  }
+
+  if (gameLoading) {
+    return (
+      <div className="min-h-screen bg-sky-950 text-white flex items-center justify-center">
+        <div className="text-sky-400">Loading room...</div>
+      </div>
+    );
+  }
+
+  const isInGame = !!user && !!gameState?.players[user.uid];
+
+  if (!gameState || !isInGame || gameState.phase === 'lobby') {
+    return (
+      <KitesLobby
+        uid={user?.uid ?? ''}
+        displayName={displayName}
+        setDisplayName={setDisplayName}
+        signIn={signIn}
+        gameState={gameState}
+        isInGame={!!isInGame}
+        roomId={roomId}
+        onLeaveRoom={handleLeaveRoom}
+      />
+    );
+  }
+
+  return (
+    <KitesGamePage
+      gameState={gameState}
+      hand={hand}
+      uid={user!.uid}
+      roomId={roomId}
+      onLeaveRoom={handleLeaveRoom}
+    />
+  );
+}

--- a/frontend/src/api-kites.ts
+++ b/frontend/src/api-kites.ts
@@ -1,0 +1,8 @@
+import { httpsCallable } from 'firebase/functions';
+import { functions } from './firebase.ts';
+
+export const kitesJoinGame = httpsCallable(functions, 'kitesJoinGame');
+export const kitesLeaveGame = httpsCallable(functions, 'kitesLeaveGame');
+export const kitesStartGame = httpsCallable(functions, 'kitesStartGame');
+export const kitesPlayCard = httpsCallable(functions, 'kitesPlayCard');
+export const kitesPlayAgain = httpsCallable(functions, 'kitesPlayAgain');

--- a/frontend/src/components/kites/KitesCardView.tsx
+++ b/frontend/src/components/kites/KitesCardView.tsx
@@ -1,0 +1,63 @@
+import type { KitesCard } from '@shared/kites/types';
+
+interface Props {
+  card: KitesCard;
+  /** Optional label badge for stack ordering. */
+  size?: 'sm' | 'md' | 'lg';
+  selectable?: boolean;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+const SYMBOL_BG: Record<string, string> = {
+  red: 'bg-red-500',
+  orange: 'bg-orange-400',
+  yellow: 'bg-yellow-400',
+  blue: 'bg-blue-500',
+  purple: 'bg-purple-500',
+};
+
+export function KitesCardView({ card, size = 'md', selectable, selected, onClick }: Props) {
+  const dims =
+    size === 'sm'
+      ? 'w-12 h-16'
+      : size === 'lg'
+      ? 'w-24 h-32'
+      : 'w-16 h-24';
+
+  return (
+    <button
+      type="button"
+      disabled={!selectable}
+      onClick={onClick}
+      className={[
+        'relative rounded-md border bg-gradient-to-br from-sky-700/60 to-sky-900/80',
+        'flex flex-col items-center justify-center gap-1',
+        dims,
+        selectable ? 'cursor-pointer hover:from-sky-600/60 hover:to-sky-800/80' : 'cursor-default',
+        selected
+          ? 'border-cyan-300 ring-2 ring-cyan-400 -translate-y-2 shadow-lg shadow-cyan-500/30'
+          : 'border-gray-700',
+        'transition-transform',
+      ].join(' ')}
+      aria-label={`Kite card with ${card.symbols.join(' and ')}`}
+    >
+      {/* Faint kite icon — chevron triangle */}
+      <div className="absolute inset-0 flex items-center justify-center opacity-25 pointer-events-none">
+        <div className="w-8 h-8 rotate-45 border-l-2 border-t-2 border-white/60" />
+      </div>
+      {/* Symbol pips */}
+      <div className="relative flex gap-1">
+        {card.symbols.map((s, i) => (
+          <span
+            key={`${s}-${i}`}
+            className={`inline-block rounded-full ${SYMBOL_BG[s]} ${
+              size === 'sm' ? 'w-2.5 h-2.5' : size === 'lg' ? 'w-5 h-5' : 'w-3.5 h-3.5'
+            } shadow ring-1 ring-black/30`}
+            title={s}
+          />
+        ))}
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/components/kites/KitesGamePage.tsx
+++ b/frontend/src/components/kites/KitesGamePage.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { KitesCard, KitesColor, KitesGameState } from '@shared/kites/types';
+import { KITES_TIMER_ORDER, kitesScoreLabel } from '@shared/kites/constants';
+import { kitesLeaveGame, kitesPlayAgain, kitesPlayCard } from '../../api-kites.ts';
+import { useToast } from '../../hooks/useToast.ts';
+import { Toast } from '../Toast.tsx';
+import { KitesSandTimer } from './KitesSandTimer.tsx';
+import { KitesCardView } from './KitesCardView.tsx';
+
+interface Props {
+  gameState: KitesGameState;
+  hand: KitesCard[];
+  uid: string;
+  roomId: string;
+  onLeaveRoom: () => void;
+}
+
+export function KitesGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Props) {
+  const [selectedCard, setSelectedCard] = useState<KitesCard | null>(null);
+  const [pendingFlip, setPendingFlip] = useState<KitesColor[] | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [restarting, setRestarting] = useState(false);
+  const { message: toast, showToast } = useToast();
+
+  // Reset selection when hand changes (eg. after submitting).
+  useEffect(() => {
+    setSelectedCard(null);
+    setPendingFlip(null);
+  }, [hand.length, gameState.totalPlayed]);
+
+  const isHost = gameState.hostUid === uid;
+  const isObserver = !gameState.players[uid];
+
+  const onCardClick = (card: KitesCard) => {
+    if (gameState.phase !== 'playing' || isObserver) return;
+    if (selectedCard?.id === card.id) {
+      setSelectedCard(null);
+      setPendingFlip(null);
+      return;
+    }
+    setSelectedCard(card);
+    if (card.symbols.length === 2) {
+      // No choice for 2-symbol cards — flip both.
+      setPendingFlip([card.symbols[0], card.symbols[1]]);
+    } else {
+      setPendingFlip(null);
+    }
+  };
+
+  const onTimerSelect = (color: KitesColor) => {
+    if (!selectedCard || selectedCard.symbols.length !== 1) return;
+    if (color !== selectedCard.symbols[0] && color !== 'white') return;
+    setPendingFlip([color]);
+  };
+
+  const onConfirmPlay = async () => {
+    if (!selectedCard || !pendingFlip) return;
+    setSubmitting(true);
+    try {
+      await kitesPlayCard({
+        roomId,
+        card: selectedCard,
+        flipColors: pendingFlip,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Play failed';
+      showToast(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRestart = async () => {
+    setRestarting(true);
+    try {
+      await kitesPlayAgain({ roomId });
+    } catch (err) {
+      console.error('Restart failed:', err);
+      showToast('Restart failed');
+    } finally {
+      setRestarting(false);
+    }
+  };
+
+  const handleLeave = async () => {
+    try {
+      await kitesLeaveGame({ roomId });
+    } catch {
+      // ignore
+    }
+    onLeaveRoom();
+  };
+
+  const timersByColor = useMemo(() => {
+    const m = new Map<KitesColor, (typeof gameState.timers)[number]>();
+    for (const t of gameState.timers) m.set(t.color as KitesColor, t);
+    return m;
+  }, [gameState]);
+
+  const totalRemaining =
+    gameState.drawPileSize +
+    Object.values(gameState.players).reduce((acc, p) => acc + p.handSize, 0);
+
+  return (
+    <div className="min-h-[100dvh] bg-gradient-to-b from-sky-800 via-sky-900 to-sky-950 text-white font-sans flex flex-col">
+      {/* Header bar */}
+      <div className="flex items-center justify-between px-3 py-2 border-b border-sky-800/60 bg-sky-950/40">
+        <div className="text-cyan-300 text-xs tracking-widest">Room {roomId}</div>
+        <div className="text-xs text-sky-300">
+          Cards left: <span className="font-bold text-sky-100">{totalRemaining}</span>
+          <span className="text-sky-500 mx-1">·</span>
+          Played: <span className="font-bold text-sky-100">{gameState.totalPlayed}</span>
+        </div>
+        <button onClick={handleLeave} className="text-xs text-sky-400 hover:text-sky-200">
+          Leave
+        </button>
+      </div>
+
+      {/* Timers strip */}
+      <div className="px-2 py-3 border-b border-sky-800/60 bg-sky-900/30">
+        <div className="flex justify-center gap-3 sm:gap-5">
+          {KITES_TIMER_ORDER.map((color) => {
+            const t = timersByColor.get(color);
+            if (!t) return null;
+            const selectable =
+              !!selectedCard &&
+              selectedCard.symbols.length === 1 &&
+              (color === selectedCard.symbols[0] || color === 'white');
+            const selected = pendingFlip?.includes(color) ?? false;
+            return (
+              <KitesSandTimer
+                key={color}
+                timer={t}
+                selectable={selectable}
+                selected={selected}
+                onClick={() => onTimerSelect(color)}
+              />
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Recent plays */}
+      <div className="flex-1 px-3 py-3 overflow-y-auto">
+        <div className="text-xs text-sky-400 mb-2">Recent plays</div>
+        {gameState.recentPlays.length === 0 ? (
+          <div className="text-xs text-sky-600 italic">No cards played yet</div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {gameState.recentPlays.slice().reverse().map((play) => {
+              const player = gameState.players[play.uid];
+              return (
+                <div key={play.id + play.seq} className="flex flex-col items-center gap-1">
+                  <KitesCardView card={{ id: play.id, symbols: play.symbols }} size="sm" />
+                  <span className="text-[10px] text-sky-400 max-w-12 truncate">
+                    {player?.displayName ?? '?'}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Status / End-of-game banner */}
+      {gameState.phase === 'won' && (
+        <EndBanner
+          title="All kites soaring!"
+          subtitle={`${kitesScoreLabel(gameState.finalScore ?? 0)}`}
+          score={gameState.finalScore}
+          isHost={isHost}
+          onRestart={handleRestart}
+          restarting={restarting}
+          variant="win"
+        />
+      )}
+      {gameState.phase === 'lost' && (
+        <EndBanner
+          title={`The ${gameState.expiredTimerColor ?? '?'} kite fell.`}
+          subtitle={kitesScoreLabel(gameState.finalScore ?? 0)}
+          score={gameState.finalScore}
+          isHost={isHost}
+          onRestart={handleRestart}
+          restarting={restarting}
+          variant="loss"
+        />
+      )}
+
+      {/* Hand + action bar */}
+      {gameState.phase === 'playing' && !isObserver && (
+        <div className="border-t border-sky-800/60 bg-sky-950/70 backdrop-blur p-3">
+          <div className="text-xs text-sky-400 mb-2">Your hand</div>
+          {hand.length === 0 ? (
+            <div className="text-sky-500 text-sm italic">Empty hand — others must keep flying.</div>
+          ) : (
+            <div className="flex gap-2 overflow-x-auto pb-1">
+              {hand.map((c) => (
+                <KitesCardView
+                  key={c.id}
+                  card={c}
+                  size="md"
+                  selectable
+                  selected={selectedCard?.id === c.id}
+                  onClick={() => onCardClick(c)}
+                />
+              ))}
+            </div>
+          )}
+
+          {selectedCard && (
+            <div className="mt-3 flex items-center justify-between gap-2">
+              <div className="text-xs text-sky-300">
+                {selectedCard.symbols.length === 2
+                  ? `Flip both ${selectedCard.symbols.join(' + ')} timers.`
+                  : pendingFlip
+                  ? `Will flip ${pendingFlip[0]} timer.`
+                  : `Tap a timer above (${selectedCard.symbols[0]} or white).`}
+              </div>
+              <button
+                onClick={onConfirmPlay}
+                disabled={!pendingFlip || submitting}
+                className="px-4 py-2 bg-cyan-600 hover:bg-cyan-500 disabled:bg-gray-700 disabled:text-gray-500 rounded text-sm font-bold"
+              >
+                {submitting ? '...' : 'Play'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {gameState.phase === 'playing' && isObserver && (
+        <div className="border-t border-sky-800/60 bg-sky-950/70 p-3 text-center text-sm text-sky-400">
+          You're watching — late joiners can't play this match.
+        </div>
+      )}
+
+      <Toast message={toast} />
+    </div>
+  );
+}
+
+interface EndBannerProps {
+  title: string;
+  subtitle: string;
+  score: number | null;
+  isHost: boolean;
+  onRestart: () => void;
+  restarting: boolean;
+  variant: 'win' | 'loss';
+}
+
+function EndBanner({ title, subtitle, score, isHost, onRestart, restarting, variant }: EndBannerProps) {
+  const accent =
+    variant === 'win'
+      ? 'border-emerald-400 bg-emerald-900/40 text-emerald-100'
+      : 'border-rose-400 bg-rose-900/40 text-rose-100';
+  return (
+    <div className={`mx-3 my-3 p-4 rounded-lg border ${accent} text-center`}>
+      <div className="text-lg font-bold mb-1">{title}</div>
+      <div className="text-sm mb-2">{subtitle}</div>
+      <div className="text-xs opacity-80 mb-3">
+        Score: <span className="font-bold">{score ?? 0}</span> {variant === 'win' ? '(perfect = 0)' : '(cards left in deck + hands)'}
+      </div>
+      {isHost && (
+        <button
+          onClick={onRestart}
+          disabled={restarting}
+          className="px-4 py-2 bg-cyan-600 hover:bg-cyan-500 disabled:bg-gray-700 rounded text-sm font-bold"
+        >
+          {restarting ? '...' : 'Play Again'}
+        </button>
+      )}
+      {!isHost && <div className="text-xs opacity-70">Waiting for host to start a new game…</div>}
+    </div>
+  );
+}

--- a/frontend/src/components/kites/KitesLobby.tsx
+++ b/frontend/src/components/kites/KitesLobby.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import type { KitesGameState } from '@shared/kites/types';
+import { KITES_MIN_PLAYERS } from '@shared/kites/constants';
+import { kitesJoinGame, kitesLeaveGame, kitesStartGame } from '../../api-kites.ts';
+import { useToast } from '../../hooks/useToast.ts';
+import { Toast } from '../Toast.tsx';
+
+interface Props {
+  uid: string;
+  displayName: string;
+  setDisplayName: (name: string) => void;
+  signIn: () => Promise<void>;
+  gameState: KitesGameState | null;
+  isInGame: boolean;
+  roomId: string;
+  onLeaveRoom: () => void;
+}
+
+export function KitesLobby({
+  uid,
+  displayName,
+  setDisplayName,
+  signIn,
+  gameState,
+  isInGame,
+  roomId,
+  onLeaveRoom,
+}: Props) {
+  const [nameInput, setNameInput] = useState(displayName);
+  const [joining, setJoining] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [leaving, setLeaving] = useState(false);
+  const { message: toast, showToast } = useToast();
+
+  const players = gameState ? Object.values(gameState.players) : [];
+  const isHost = gameState?.hostUid === uid;
+  const canStart = isHost && (gameState?.playerOrder.length ?? 0) >= KITES_MIN_PLAYERS;
+
+  const handleJoin = async () => {
+    if (!nameInput.trim()) return;
+    setJoining(true);
+    try {
+      setDisplayName(nameInput.trim());
+      await signIn();
+      await kitesJoinGame({ roomId, displayName: nameInput.trim(), create: !gameState });
+    } catch (err) {
+      console.error('Failed to join:', err);
+      showToast('Failed to join game — try again');
+    } finally {
+      setJoining(false);
+    }
+  };
+
+  const handleStart = async () => {
+    setStarting(true);
+    try {
+      await kitesStartGame({ roomId });
+    } catch (err) {
+      console.error('Failed to start game:', err);
+      showToast('Failed to start game');
+      setStarting(false);
+    }
+  };
+
+  const handleLeave = async () => {
+    setLeaving(true);
+    try {
+      await kitesLeaveGame({ roomId });
+      onLeaveRoom();
+    } catch (err) {
+      console.error('Failed to leave:', err);
+      showToast('Failed to leave');
+      setLeaving(false);
+    }
+  };
+
+  if (isInGame && gameState) {
+    return (
+      <div className="min-h-screen bg-gradient-to-b from-sky-900 to-sky-950 text-white flex items-center justify-center font-sans">
+        <div className="border border-sky-700/60 bg-sky-950/80 backdrop-blur p-6 rounded-lg max-w-sm w-full mx-4 shadow-2xl shadow-sky-500/10">
+          <h1 className="text-2xl font-bold text-center mb-1 tracking-wide">Kites</h1>
+          <p className="text-sky-300 text-center text-xs mb-1">Cooperative real-time</p>
+          <p className="text-cyan-300 text-center text-xs mb-4 tracking-widest">Room: {roomId}</p>
+
+          <div className="mb-4">
+            <div className="text-xs text-sky-400 mb-2">Pilots ({players.length})</div>
+            {players.map((p) => (
+              <div key={p.uid} className="text-sm py-0.5 flex items-center gap-2">
+                {p.uid === gameState.hostUid && <span className="text-yellow-300">★</span>}
+                <span className="text-sky-100">{p.displayName}</span>
+                {p.uid === uid && <span className="text-sky-500 text-xs">(you)</span>}
+              </div>
+            ))}
+          </div>
+
+          <div className="space-y-2">
+            {isHost ? (
+              <button
+                onClick={handleStart}
+                disabled={!canStart || starting}
+                className="w-full py-2 bg-cyan-600 hover:bg-cyan-500 disabled:bg-gray-700 disabled:text-gray-500 text-white text-sm font-bold rounded"
+              >
+                {starting ? 'Lifting off...' : canStart ? 'Start Flying' : `Need ${KITES_MIN_PLAYERS}+ pilots`}
+              </button>
+            ) : (
+              <div className="w-full py-2 text-center text-sky-400 text-sm">
+                Waiting for host to start...
+              </div>
+            )}
+            <button
+              onClick={handleLeave}
+              disabled={leaving}
+              className="w-full py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 text-gray-300 text-sm rounded"
+            >
+              {leaving ? '...' : 'Leave'}
+            </button>
+          </div>
+        </div>
+        <Toast message={toast} />
+      </div>
+    );
+  }
+
+  // Not in game — join form
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-sky-900 to-sky-950 text-white flex items-center justify-center font-sans">
+      <div className="border border-sky-700/60 bg-sky-950/80 backdrop-blur p-6 rounded-lg max-w-sm w-full mx-4 shadow-2xl shadow-sky-500/10">
+        <h1 className="text-2xl font-bold text-center mb-1 tracking-wide">Kites</h1>
+        <p className="text-sky-300 text-center text-xs mb-1">Cooperative real-time</p>
+        <p className="text-cyan-300 text-center text-xs mb-4 tracking-widest">Room: {roomId}</p>
+
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="kites-name" className="block text-xs text-sky-400 mb-1">
+              Display Name
+            </label>
+            <input
+              id="kites-name"
+              type="text"
+              value={nameInput}
+              onChange={(e) => setNameInput(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
+              placeholder="Pilot name"
+              maxLength={20}
+              className="w-full px-3 py-2 bg-sky-900/50 border border-sky-700 text-white placeholder-sky-600 focus:outline-none focus:border-cyan-400 text-sm rounded"
+            />
+          </div>
+          <button
+            onClick={handleJoin}
+            disabled={!nameInput.trim() || joining}
+            className="w-full py-2 bg-cyan-600 hover:bg-cyan-500 disabled:bg-gray-700 disabled:text-gray-500 text-white text-sm font-bold rounded"
+          >
+            {joining ? 'Joining...' : 'Join Game'}
+          </button>
+        </div>
+
+        {players.length > 0 && (
+          <div className="mt-4 pt-3 border-t border-sky-800">
+            <div className="text-xs text-sky-400 mb-2">Pilots at table ({players.length})</div>
+            {players.map((p) => (
+              <div key={p.uid} className="text-xs text-sky-200 py-0.5">
+                {p.displayName}
+                {p.uid === uid && ' (you)'}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="mt-4 pt-3 border-t border-sky-800 flex justify-center">
+          <button onClick={onLeaveRoom} className="text-xs text-sky-500 hover:text-sky-300">
+            ← Back
+          </button>
+        </div>
+      </div>
+      <Toast message={toast} />
+    </div>
+  );
+}

--- a/frontend/src/components/kites/KitesRoomSelector.tsx
+++ b/frontend/src/components/kites/KitesRoomSelector.tsx
@@ -1,18 +1,18 @@
 import { useState } from 'react';
-import { joinGame } from '../api.ts';
-import { trackEvent } from '../firebase.ts';
-import { useToast } from '../hooks/useToast.ts';
-import { generateRoomCode } from '../utils/roomCode.ts';
-import { Toast } from './Toast.tsx';
+import { kitesJoinGame } from '../../api-kites.ts';
+import { useToast } from '../../hooks/useToast.ts';
+import { generateRoomCode } from '../../utils/roomCode.ts';
+import { Toast } from '../Toast.tsx';
 
-interface RoomSelectorProps {
+interface Props {
   displayName: string;
   setDisplayName: (name: string) => void;
   signIn: () => Promise<void>;
   onRoomJoined: (roomId: string) => void;
+  onSwitchGame?: () => void;
 }
 
-export function RoomSelector({ displayName, setDisplayName, signIn, onRoomJoined }: RoomSelectorProps) {
+export function KitesRoomSelector({ displayName, setDisplayName, signIn, onRoomJoined, onSwitchGame }: Props) {
   const [nameInput, setNameInput] = useState(displayName);
   const [roomCodeInput, setRoomCodeInput] = useState('');
   const [creating, setCreating] = useState(false);
@@ -26,8 +26,7 @@ export function RoomSelector({ displayName, setDisplayName, signIn, onRoomJoined
       setDisplayName(nameInput.trim());
       await signIn();
       const roomId = generateRoomCode();
-      await joinGame({ roomId, displayName: nameInput.trim(), create: true });
-      trackEvent('create_room', { roomId });
+      await kitesJoinGame({ roomId, displayName: nameInput.trim(), create: true });
       onRoomJoined(roomId);
     } catch (err) {
       console.error('Failed to create room:', err);
@@ -44,8 +43,7 @@ export function RoomSelector({ displayName, setDisplayName, signIn, onRoomJoined
       setDisplayName(nameInput.trim());
       await signIn();
       const roomId = roomCodeInput.trim().toUpperCase();
-      await joinGame({ roomId, displayName: nameInput.trim() });
-      trackEvent('join_room', { roomId });
+      await kitesJoinGame({ roomId, displayName: nameInput.trim() });
       onRoomJoined(roomId);
     } catch (err) {
       console.error('Failed to join room:', err);
@@ -56,72 +54,71 @@ export function RoomSelector({ displayName, setDisplayName, signIn, onRoomJoined
   };
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center font-mono">
-      <div className="border border-gray-700 p-6 max-w-sm w-full mx-4">
-        <h1 className="text-xl font-bold text-center mb-1">Pineapple Poker</h1>
-        <p className="text-gray-500 text-center text-xs mb-4">Open Face Chinese</p>
+    <div className="min-h-screen bg-gradient-to-b from-sky-900 to-sky-950 text-white flex items-center justify-center font-sans">
+      <div className="border border-sky-700/60 bg-sky-950/80 backdrop-blur p-6 rounded-lg max-w-sm w-full mx-4 shadow-2xl shadow-sky-500/10">
+        <h1 className="text-3xl font-bold text-center mb-1 tracking-wide">Kites</h1>
+        <p className="text-sky-300 text-center text-xs mb-5">Cooperative · Real-time · 2–6 pilots</p>
 
         <div className="space-y-3">
           <div>
-            <label htmlFor="name" className="block text-xs text-gray-500 mb-1">
+            <label htmlFor="kites-name" className="block text-xs text-sky-400 mb-1">
               Display Name
             </label>
             <input
-              id="name"
-              data-testid="name-input"
+              id="kites-name"
               type="text"
               value={nameInput}
               onChange={(e) => setNameInput(e.target.value)}
-              placeholder="Enter your name"
+              placeholder="Pilot name"
               maxLength={20}
-              className="w-full px-3 py-2 bg-gray-800 border border-gray-600 text-white placeholder-gray-500 focus:outline-none focus:border-green-500 text-sm"
+              className="w-full px-3 py-2 bg-sky-900/50 border border-sky-700 text-white placeholder-sky-600 focus:outline-none focus:border-cyan-400 text-sm rounded"
             />
           </div>
 
           <button
-            data-testid="create-room-button"
             onClick={handleCreate}
             disabled={!nameInput.trim() || creating}
-            className="w-full py-2 bg-green-700 hover:bg-green-600 disabled:bg-gray-700 disabled:text-gray-500 text-white text-sm font-bold"
+            className="w-full py-2 bg-cyan-600 hover:bg-cyan-500 disabled:bg-gray-700 disabled:text-gray-500 text-white text-sm font-bold rounded"
           >
             {creating ? 'Creating...' : 'Create Room'}
           </button>
 
-          <div className="flex items-center gap-2 text-gray-600 text-xs">
-            <div className="flex-1 border-t border-gray-700" />
+          <div className="flex items-center gap-2 text-sky-600 text-xs">
+            <div className="flex-1 border-t border-sky-800" />
             or join
-            <div className="flex-1 border-t border-gray-700" />
+            <div className="flex-1 border-t border-sky-800" />
           </div>
 
           <div className="flex gap-2">
             <input
-              data-testid="room-code-input"
               type="text"
               value={roomCodeInput}
               onChange={(e) => setRoomCodeInput(e.target.value.toUpperCase())}
               onKeyDown={(e) => e.key === 'Enter' && handleJoin()}
               placeholder="Room code"
               maxLength={6}
-              className="flex-1 px-3 py-2 bg-gray-800 border border-gray-600 text-white placeholder-gray-500 focus:outline-none focus:border-green-500 text-sm uppercase tracking-widest"
+              className="flex-1 px-3 py-2 bg-sky-900/50 border border-sky-700 text-white placeholder-sky-600 focus:outline-none focus:border-cyan-400 text-sm uppercase tracking-widest rounded"
             />
             <button
-              data-testid="join-room-button"
               onClick={handleJoin}
               disabled={!nameInput.trim() || !roomCodeInput.trim() || joining}
-              className="px-4 py-2 bg-blue-700 hover:bg-blue-600 disabled:bg-gray-700 disabled:text-gray-500 text-white text-sm font-bold"
+              className="px-4 py-2 bg-sky-700 hover:bg-sky-600 disabled:bg-gray-700 disabled:text-gray-500 text-white text-sm font-bold rounded"
             >
               {joining ? '...' : 'Join'}
             </button>
           </div>
         </div>
-        <div className="mt-4 pt-3 border-t border-gray-700 flex justify-center">
-          <a
-            href="?game=kites"
-            className="text-xs text-cyan-400 hover:text-cyan-300"
-          >
-            Try Kites (cooperative) →
-          </a>
-        </div>
+
+        {onSwitchGame && (
+          <div className="mt-4 pt-3 border-t border-sky-800 flex justify-center">
+            <button
+              onClick={onSwitchGame}
+              className="text-xs text-sky-400 hover:text-sky-200"
+            >
+              ← Switch to Pineapple Poker
+            </button>
+          </div>
+        )}
       </div>
       <Toast message={toast} />
     </div>

--- a/frontend/src/components/kites/KitesSandTimer.tsx
+++ b/frontend/src/components/kites/KitesSandTimer.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import type { KitesTimer } from '@shared/kites/types';
+
+interface Props {
+  timer: KitesTimer;
+  /** When true, shows a flip pulse on the timer. */
+  isHighlighted?: boolean;
+  /** When true, the timer is selectable and shows a click cursor. */
+  selectable?: boolean;
+  selected?: boolean;
+  onClick?: () => void;
+}
+
+const COLOR_CLASSES: Record<string, { bulb: string; sand: string; ring: string; label: string }> = {
+  red: { bulb: 'from-red-300/50 to-red-100/30', sand: 'bg-red-500', ring: 'ring-red-400', label: 'text-red-300' },
+  orange: { bulb: 'from-orange-300/50 to-orange-100/30', sand: 'bg-orange-400', ring: 'ring-orange-400', label: 'text-orange-300' },
+  yellow: { bulb: 'from-yellow-200/50 to-yellow-100/30', sand: 'bg-yellow-400', ring: 'ring-yellow-300', label: 'text-yellow-200' },
+  white: { bulb: 'from-gray-200/50 to-gray-100/30', sand: 'bg-gray-200', ring: 'ring-white', label: 'text-gray-100' },
+  blue: { bulb: 'from-blue-300/50 to-blue-100/30', sand: 'bg-blue-400', ring: 'ring-blue-400', label: 'text-blue-300' },
+  purple: { bulb: 'from-purple-300/50 to-purple-100/30', sand: 'bg-purple-400', ring: 'ring-purple-400', label: 'text-purple-300' },
+};
+
+export function KitesSandTimer({ timer, isHighlighted, selectable, selected, onClick }: Props) {
+  // Tick at 16Hz for smooth sand drain animation.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 60);
+    return () => clearInterval(id);
+  }, []);
+
+  const flowing = timer.flippedAt !== null;
+  const elapsed = flowing ? Math.max(0, now - (timer.flippedAt as number)) : 0;
+  const remaining = flowing ? Math.max(0, timer.durationMs - elapsed) : timer.durationMs;
+  const fraction = flowing ? remaining / timer.durationMs : 1;
+  const expired = flowing && remaining <= 0;
+  const danger = flowing && fraction < 0.25 && !expired;
+
+  const c = COLOR_CLASSES[timer.color] ?? COLOR_CLASSES.white;
+  const topPct = fraction * 100;          // sand left in top bulb
+  const bottomPct = (1 - fraction) * 100; // sand accumulated in bottom
+
+  return (
+    <button
+      type="button"
+      onClick={selectable ? onClick : undefined}
+      disabled={!selectable}
+      className={[
+        'relative flex flex-col items-center gap-1 select-none',
+        selectable ? 'cursor-pointer' : 'cursor-default',
+        selected ? `ring-2 ring-offset-2 ring-offset-gray-950 ${c.ring} rounded-md` : '',
+        isHighlighted ? 'animate-pulse' : '',
+      ].join(' ')}
+      aria-label={`${timer.color} timer, ${flowing ? `${Math.ceil(remaining / 1000)} seconds remaining` : 'paused'}`}
+    >
+      {/* Hourglass body */}
+      <div className="relative w-10 h-16 flex flex-col">
+        {/* Top bulb */}
+        <div className={`relative flex-1 rounded-t-lg overflow-hidden border border-gray-700 bg-gradient-to-b ${c.bulb}`}>
+          <div
+            className={`absolute left-0 right-0 top-0 ${c.sand}`}
+            style={{ height: `${topPct}%`, transition: 'height 80ms linear' }}
+          />
+        </div>
+        {/* Pinch */}
+        <div className="h-0.5 w-2 self-center bg-gray-700" />
+        {/* Bottom bulb */}
+        <div className={`relative flex-1 rounded-b-lg overflow-hidden border border-gray-700 bg-gradient-to-b ${c.bulb}`}>
+          <div
+            className={`absolute left-0 right-0 bottom-0 ${c.sand}`}
+            style={{ height: `${bottomPct}%`, transition: 'height 80ms linear' }}
+          />
+        </div>
+      </div>
+
+      <div className={`text-[10px] uppercase tracking-wider ${c.label} ${danger ? 'animate-pulse text-red-300' : ''}`}>
+        {expired ? 'OUT' : flowing ? `${Math.ceil(remaining / 1000)}s` : '—'}
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/hooks/kites/useKitesGameState.ts
+++ b/frontend/src/hooks/kites/useKitesGameState.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '../../firebase.ts';
+import type { KitesGameState } from '@shared/kites/types';
+import { parseKitesGameState } from '@shared/kites/schemas';
+
+export function useKitesGameState(roomId: string | null) {
+  const [gameState, setGameState] = useState<KitesGameState | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [prevRoomId, setPrevRoomId] = useState(roomId);
+  if (prevRoomId !== roomId) {
+    setPrevRoomId(roomId);
+    if (!roomId) {
+      setGameState(null);
+      setLoading(false);
+    } else {
+      setLoading(true);
+    }
+  }
+
+  useEffect(() => {
+    if (!roomId) return;
+    const unsub = onSnapshot(
+      doc(db, 'kitesGames', roomId),
+      (snap) => {
+        if (snap.exists()) {
+          try {
+            setGameState(parseKitesGameState(snap.data()));
+          } catch (err) {
+            console.error('[useKitesGameState] Parse error:', err);
+          }
+        } else {
+          setGameState(null);
+        }
+        setLoading(false);
+      },
+      (err) => {
+        console.error('[useKitesGameState] Listener error:', err);
+        setLoading(false);
+      },
+    );
+    return unsub;
+  }, [roomId]);
+
+  return { gameState, loading };
+}

--- a/frontend/src/hooks/kites/useKitesHand.ts
+++ b/frontend/src/hooks/kites/useKitesHand.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { db } from '../../firebase.ts';
+import type { KitesCard } from '@shared/kites/types';
+import { parseKitesHandDoc } from '@shared/kites/schemas';
+
+export function useKitesHand(uid: string | undefined, roomId: string | null) {
+  const [hand, setHand] = useState<KitesCard[]>([]);
+
+  // Reset hand synchronously when subscription identity changes — avoids
+  // briefly showing stale cards after switching room or signing out.
+  const [prevKey, setPrevKey] = useState<string | null>(uid && roomId ? `${uid}:${roomId}` : null);
+  const key = uid && roomId ? `${uid}:${roomId}` : null;
+  if (prevKey !== key) {
+    setPrevKey(key);
+    setHand([]);
+  }
+
+  useEffect(() => {
+    if (!uid || !roomId) return;
+    const unsub = onSnapshot(
+      doc(db, 'kitesGames', roomId, 'hands', uid),
+      (snap) => {
+        if (snap.exists()) {
+          try {
+            setHand(parseKitesHandDoc(snap.data()).cards);
+          } catch (err) {
+            console.error('[useKitesHand] Parse error:', err);
+            setHand([]);
+          }
+        } else {
+          setHand([]);
+        }
+      },
+      (err) => console.error('[useKitesHand] Listener error:', err),
+    );
+    return unsub;
+  }, [uid, roomId]);
+
+  return hand;
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,3 +5,10 @@ admin.initializeApp();
 export { joinGame, leaveGame, placeCards, startMatch, playAgain, addBot, removeBot, pickCharm, pickMutation } from './player-actions';
 export { pruneOldGames } from './cleanup';
 export { adminDeleteRoom, adminKickPlayer, adminKillAllGames } from './admin-actions';
+export {
+  kitesJoinGame,
+  kitesLeaveGame,
+  kitesStartGame,
+  kitesPlayCard,
+  kitesPlayAgain,
+} from './kites-actions';

--- a/functions/src/kites-actions.ts
+++ b/functions/src/kites-actions.ts
@@ -1,0 +1,465 @@
+import { onCall, HttpsError } from 'firebase-functions/v2/https';
+import * as admin from 'firebase-admin';
+import { z } from 'zod';
+import type {
+  KitesCard,
+  KitesGameState,
+  KitesPlayedCard,
+  KitesPlayer,
+  KitesTimer,
+  KitesColor,
+} from '../../shared/kites/types';
+import { KitesPhase } from '../../shared/kites/types';
+import {
+  KITES_MAX_PLAYERS,
+  KITES_MIN_PLAYERS,
+  KITES_RECENT_PLAYS_CAP,
+  emptyTimers,
+  kitesHandSize,
+} from '../../shared/kites/constants';
+import {
+  kitesGameDoc,
+  kitesHandDoc,
+  kitesDeckDoc,
+} from '../../shared/kites/firestore-paths';
+import {
+  parseKitesGameState,
+  parseKitesHandDoc,
+  parseKitesDeckDoc,
+  KitesCardSchema,
+} from '../../shared/kites/schemas';
+import {
+  createKitesDeck,
+  dealKitesCards,
+  shuffleKitesDeck,
+} from '../../shared/kites/deck';
+import {
+  cardsRemaining,
+  nextTimerToExpire,
+  validateFlipChoice,
+} from '../../shared/kites/game-logic';
+
+const db = () => admin.firestore();
+
+// ---- Schemas ----
+
+const RoomIdSchema = z.object({
+  roomId: z.string().min(1),
+});
+
+const JoinSchema = RoomIdSchema.extend({
+  displayName: z.string().optional(),
+  create: z.boolean().optional(),
+});
+
+const PlayCardSchema = RoomIdSchema.extend({
+  card: KitesCardSchema,
+  flipColors: z
+    .array(z.enum(['red', 'orange', 'yellow', 'white', 'blue', 'purple']))
+    .min(1)
+    .max(2),
+});
+
+function newPlayer(uid: string, displayName: string): KitesPlayer {
+  return {
+    uid,
+    displayName,
+    handSize: 0,
+    disconnected: false,
+  };
+}
+
+function emptyKitesGame(uid: string, roomId: string, displayName: string): KitesGameState {
+  const now = Date.now();
+  return {
+    gameId: roomId,
+    gameType: 'kites',
+    phase: KitesPhase.Lobby,
+    hostUid: uid,
+    players: { [uid]: newPlayer(uid, displayName) },
+    playerOrder: [uid],
+    timers: emptyTimers(),
+    drawPileSize: 0,
+    recentPlays: [],
+    totalPlayed: 0,
+    endedAt: null,
+    finalScore: null,
+    endReason: null,
+    expiredTimerColor: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+// ---- kitesJoinGame ----
+
+export const kitesJoinGame = onCall({ maxInstances: 10 }, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError('unauthenticated', 'Must be signed in.');
+
+  const parsed = JoinSchema.safeParse(request.data);
+  if (!parsed.success) {
+    throw new HttpsError('invalid-argument', 'Invalid request.');
+  }
+  const { roomId, create } = parsed.data;
+  const displayName = parsed.data.displayName || `Player_${uid.slice(0, 6)}`;
+  const ref = db().doc(kitesGameDoc(roomId));
+
+  await db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) {
+      if (!create) throw new HttpsError('not-found', 'Room not found.');
+      tx.set(ref, emptyKitesGame(uid, roomId, displayName));
+      return;
+    }
+    const game = parseKitesGameState(snap.data());
+    if (game.players[uid]) return;
+    if (Object.keys(game.players).length >= KITES_MAX_PLAYERS) {
+      throw new HttpsError('resource-exhausted', `Room is full (max ${KITES_MAX_PLAYERS}).`);
+    }
+    if (game.phase !== KitesPhase.Lobby) {
+      throw new HttpsError('failed-precondition', 'Game already started — cannot join.');
+    }
+    const players = { ...game.players, [uid]: newPlayer(uid, displayName) };
+    const playerOrder = [...game.playerOrder, uid];
+    tx.update(ref, {
+      players,
+      playerOrder,
+      updatedAt: Date.now(),
+    });
+  });
+
+  return { success: true };
+});
+
+// ---- kitesLeaveGame ----
+
+export const kitesLeaveGame = onCall({ maxInstances: 10 }, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError('unauthenticated', 'Must be signed in.');
+
+  const parsed = RoomIdSchema.safeParse(request.data);
+  if (!parsed.success) throw new HttpsError('invalid-argument', 'Invalid request.');
+  const { roomId } = parsed.data;
+  const ref = db().doc(kitesGameDoc(roomId));
+
+  await db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) return;
+    const game = parseKitesGameState(snap.data());
+    if (!game.players[uid]) return;
+
+    const players = { ...game.players };
+    delete players[uid];
+    const playerOrder = game.playerOrder.filter((u) => u !== uid);
+
+    tx.delete(db().doc(kitesHandDoc(uid, roomId)));
+
+    if (Object.keys(players).length === 0) {
+      tx.delete(ref);
+      tx.delete(db().doc(kitesDeckDoc(roomId)));
+      return;
+    }
+
+    const update: Partial<KitesGameState> = {
+      players,
+      playerOrder,
+      updatedAt: Date.now(),
+    };
+    if (uid === game.hostUid && playerOrder.length > 0) {
+      update.hostUid = playerOrder[0];
+    }
+    tx.update(ref, update);
+  });
+
+  return { success: true };
+});
+
+// ---- kitesStartGame ----
+
+export const kitesStartGame = onCall({ maxInstances: 10 }, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError('unauthenticated', 'Must be signed in.');
+
+  const parsed = RoomIdSchema.safeParse(request.data);
+  if (!parsed.success) throw new HttpsError('invalid-argument', 'Invalid request.');
+  const { roomId } = parsed.data;
+  const ref = db().doc(kitesGameDoc(roomId));
+
+  await db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) throw new HttpsError('not-found', 'Room not found.');
+
+    const game = parseKitesGameState(snap.data());
+    if (game.hostUid !== uid) {
+      throw new HttpsError('permission-denied', 'Only the host can start the game.');
+    }
+    if (game.phase !== KitesPhase.Lobby) {
+      throw new HttpsError('failed-precondition', 'Game already in progress.');
+    }
+    if (game.playerOrder.length < KITES_MIN_PLAYERS) {
+      throw new HttpsError('failed-precondition', `Need at least ${KITES_MIN_PLAYERS} players.`);
+    }
+
+    const playerCount = game.playerOrder.length;
+    const handSize = kitesHandSize(playerCount);
+    const deck = shuffleKitesDeck(createKitesDeck());
+
+    let cursor = deck;
+    const players = { ...game.players };
+    for (const pUid of game.playerOrder) {
+      const { dealt, remaining } = dealKitesCards(cursor, handSize);
+      cursor = remaining;
+      tx.set(db().doc(kitesHandDoc(pUid, roomId)), { cards: dealt });
+      players[pUid] = { ...players[pUid], handSize: dealt.length };
+    }
+
+    // White timer is stood up at the start — the others stay on their sides
+    // until a matching card is played.
+    const now = Date.now();
+    const timers = emptyTimers().map((t) =>
+      t.color === 'white' ? { ...t, flippedAt: now } : t,
+    );
+
+    tx.set(db().doc(kitesDeckDoc(roomId)), { cards: cursor });
+
+    tx.update(ref, {
+      phase: KitesPhase.Playing,
+      players,
+      timers,
+      drawPileSize: cursor.length,
+      recentPlays: [],
+      totalPlayed: 0,
+      endedAt: null,
+      finalScore: null,
+      endReason: null,
+      expiredTimerColor: null,
+      updatedAt: now,
+    });
+  });
+
+  return { success: true };
+});
+
+// ---- kitesPlayCard ----
+
+interface PlayCardRequest {
+  roomId: string;
+  card: KitesCard;
+  flipColors: KitesColor[];
+}
+
+export const kitesPlayCard = onCall({ maxInstances: 20 }, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError('unauthenticated', 'Must be signed in.');
+
+  const parsed = PlayCardSchema.safeParse(request.data);
+  if (!parsed.success) throw new HttpsError('invalid-argument', 'Invalid request.');
+  const { roomId, card, flipColors } = parsed.data as unknown as PlayCardRequest;
+
+  const gameRef = db().doc(kitesGameDoc(roomId));
+  const handRef = db().doc(kitesHandDoc(uid, roomId));
+  const deckRef = db().doc(kitesDeckDoc(roomId));
+
+  await db().runTransaction(async (tx) => {
+    // ---- All reads first ----
+    const [gameSnap, handSnap, deckSnap] = await Promise.all([
+      tx.get(gameRef),
+      tx.get(handRef),
+      tx.get(deckRef),
+    ]);
+
+    if (!gameSnap.exists) throw new HttpsError('not-found', 'Game not found.');
+    const game = parseKitesGameState(gameSnap.data());
+
+    if (game.phase !== KitesPhase.Playing) {
+      throw new HttpsError('failed-precondition', 'Game not in progress.');
+    }
+    if (!game.players[uid]) {
+      throw new HttpsError('not-found', 'You are not in this game.');
+    }
+
+    // Check if any timer already expired — end the game now if so.
+    const now = Date.now();
+    const expired = game.timers.find(
+      (t) => t.flippedAt !== null && now >= t.flippedAt + t.durationMs,
+    );
+    if (expired) {
+      const finalScore = cardsRemaining(game);
+      tx.update(gameRef, {
+        phase: KitesPhase.Lost,
+        endedAt: now,
+        endReason: 'timer_expired',
+        expiredTimerColor: expired.color,
+        finalScore,
+        updatedAt: now,
+      });
+      throw new HttpsError(
+        'failed-precondition',
+        `${expired.color} timer ran out — game over.`,
+      );
+    }
+
+    if (!handSnap.exists) throw new HttpsError('not-found', 'No hand for player.');
+    const hand = parseKitesHandDoc(handSnap.data());
+
+    // Validate the played card is in the player's hand.
+    const cardIdx = hand.cards.findIndex((c) => c.id === card.id);
+    if (cardIdx < 0) {
+      throw new HttpsError('failed-precondition', 'Card not in hand.');
+    }
+    const playedCard = hand.cards[cardIdx];
+
+    // Validate flip choice matches card symbols.
+    const err = validateFlipChoice(playedCard.symbols, flipColors);
+    if (err) throw new HttpsError('invalid-argument', err);
+
+    // ---- All writes ----
+
+    // 1. Update timers: flip selected ones to now.
+    const flipSet = new Set(flipColors);
+    const updatedTimers: KitesTimer[] = game.timers.map((t) =>
+      flipSet.has(t.color) ? { ...t, flippedAt: now } : t,
+    );
+
+    // 2. Remove card from hand, draw replacement if deck has cards.
+    const newHand = [...hand.cards];
+    newHand.splice(cardIdx, 1);
+
+    let drawPileSize = game.drawPileSize;
+    if (deckSnap.exists) {
+      const deck = parseKitesDeckDoc(deckSnap.data());
+      if (deck.cards.length > 0) {
+        const drawn = deck.cards[0];
+        newHand.push(drawn);
+        const remaining = deck.cards.slice(1);
+        tx.update(deckRef, { cards: remaining });
+        drawPileSize = remaining.length;
+      }
+    }
+
+    tx.update(handRef, { cards: newHand });
+
+    // 3. Update player hand size, recentPlays, totalPlayed.
+    const newSeq = game.totalPlayed + 1;
+    const playedEntry: KitesPlayedCard = {
+      id: playedCard.id,
+      uid,
+      symbols: playedCard.symbols,
+      seq: newSeq,
+    };
+    const recent = [...game.recentPlays, playedEntry];
+    while (recent.length > KITES_RECENT_PLAYS_CAP) recent.shift();
+
+    const players = {
+      ...game.players,
+      [uid]: { ...game.players[uid], handSize: newHand.length },
+    };
+
+    // 4. Determine next phase (win when no cards anywhere remain).
+    let phase: typeof KitesPhase[keyof typeof KitesPhase] = game.phase;
+    let endedAt: number | null = null;
+    let finalScore: number | null = null;
+    let endReason: 'win' | 'timer_expired' | null = null;
+    const totalRemaining =
+      drawPileSize +
+      Object.values(players).reduce((acc, p) => acc + p.handSize, 0);
+    if (totalRemaining === 0) {
+      phase = KitesPhase.Won;
+      endedAt = now;
+      finalScore = 0;
+      endReason = 'win';
+    }
+
+    tx.update(gameRef, {
+      timers: updatedTimers,
+      players,
+      recentPlays: recent,
+      totalPlayed: newSeq,
+      drawPileSize,
+      phase,
+      endedAt,
+      finalScore,
+      endReason,
+      updatedAt: now,
+    });
+  });
+
+  return { success: true };
+});
+
+// ---- kitesPlayAgain ----
+
+export const kitesPlayAgain = onCall({ maxInstances: 10 }, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) throw new HttpsError('unauthenticated', 'Must be signed in.');
+
+  const parsed = RoomIdSchema.safeParse(request.data);
+  if (!parsed.success) throw new HttpsError('invalid-argument', 'Invalid request.');
+  const { roomId } = parsed.data;
+  const ref = db().doc(kitesGameDoc(roomId));
+
+  await db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) throw new HttpsError('not-found', 'Room not found.');
+    const game = parseKitesGameState(snap.data());
+
+    if (game.hostUid !== uid) {
+      throw new HttpsError('permission-denied', 'Only the host can restart.');
+    }
+    if (game.phase !== KitesPhase.Won && game.phase !== KitesPhase.Lost) {
+      throw new HttpsError('failed-precondition', 'Game not finished.');
+    }
+
+    // Clear hands.
+    for (const pUid of Object.keys(game.players)) {
+      tx.delete(db().doc(kitesHandDoc(pUid, roomId)));
+    }
+    tx.delete(db().doc(kitesDeckDoc(roomId)));
+
+    const players: Record<string, KitesPlayer> = {};
+    for (const pUid of Object.keys(game.players)) {
+      players[pUid] = { ...game.players[pUid], handSize: 0 };
+    }
+
+    tx.update(ref, {
+      phase: KitesPhase.Lobby,
+      players,
+      timers: emptyTimers(),
+      drawPileSize: 0,
+      recentPlays: [],
+      totalPlayed: 0,
+      endedAt: null,
+      finalScore: null,
+      endReason: null,
+      expiredTimerColor: null,
+      updatedAt: Date.now(),
+    });
+  });
+
+  return { success: true };
+});
+
+// ---- Internal helper: end the game when a timer expires ----
+// Called by the dealer when a setTimeout fires for the soonest-expiring timer.
+export async function endGameOnTimerExpiry(roomId: string): Promise<void> {
+  const ref = db().doc(kitesGameDoc(roomId));
+  await db().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    if (!snap.exists) return;
+    const game = parseKitesGameState(snap.data());
+    if (game.phase !== KitesPhase.Playing) return;
+    const now = Date.now();
+    const next = nextTimerToExpire(game);
+    if (!next || next.expiresAt > now) return;
+    const finalScore = cardsRemaining(game);
+    tx.update(ref, {
+      phase: KitesPhase.Lost,
+      endedAt: now,
+      endReason: 'timer_expired',
+      expiredTimerColor: next.timer.color,
+      finalScore,
+      updatedAt: now,
+    });
+  });
+}

--- a/shared/kites/constants.ts
+++ b/shared/kites/constants.ts
@@ -1,0 +1,88 @@
+import type { KitesCardColor, KitesColor, KitesTimer } from './types';
+import { KitesColor as KC } from './types';
+
+/** Timer durations from the rulebook (ms). */
+export const KITES_TIMER_DURATION_MS: Record<KitesColor, number> = {
+  red: 30_000,
+  orange: 45_000,
+  yellow: 60_000,
+  white: 60_000,
+  blue: 75_000,
+  purple: 90_000,
+};
+
+/** Display order for the 6 timers (left-to-right in the UI). */
+export const KITES_TIMER_ORDER: KitesColor[] = [
+  KC.Red,
+  KC.Orange,
+  KC.Yellow,
+  KC.White,
+  KC.Blue,
+  KC.Purple,
+];
+
+/** Hand size by player count. */
+export function kitesHandSize(playerCount: number): number {
+  if (playerCount <= 2) return 5;
+  if (playerCount <= 4) return 4;
+  return 3;
+}
+
+export const KITES_MIN_PLAYERS = 2;
+export const KITES_MAX_PLAYERS = 6;
+
+/** Cap on the recentPlays array so the public game doc stays small. */
+export const KITES_RECENT_PLAYS_CAP = 12;
+
+/**
+ * Kite card distribution. 53 cards total (matches the rulebook).
+ * Singles per timer color (5 colors): heavier weight on slower timers,
+ * since faster timers need more frequent flips.
+ *   red:5 + orange:6 + yellow:7 + blue:9 + purple:10 = 37 singles.
+ * Doubles: 16 across all 10 unordered color pairs (~1-2 each).
+ */
+export const KITES_SINGLE_COUNTS: Record<KitesCardColor, number> = {
+  red: 5,
+  orange: 6,
+  yellow: 7,
+  blue: 9,
+  purple: 10,
+};
+
+/** Pair counts. Keyed by 'colorA-colorB' with colors sorted alphabetically. */
+export const KITES_DOUBLE_COUNTS: Record<string, number> = {
+  'orange-red': 2,
+  'red-yellow': 2,
+  'blue-red': 1,
+  'purple-red': 1,
+  'orange-yellow': 2,
+  'blue-orange': 2,
+  'orange-purple': 1,
+  'blue-yellow': 2,
+  'purple-yellow': 1,
+  'blue-purple': 2,
+};
+
+/** Total deck size — sanity-checked by createKitesDeck(). */
+export const KITES_DECK_SIZE = 53;
+
+export function emptyTimers(): KitesTimer[] {
+  return KITES_TIMER_ORDER.map((color) => ({
+    color,
+    durationMs: KITES_TIMER_DURATION_MS[color],
+    flippedAt: null,
+  }));
+}
+
+/**
+ * Score tiers from the rulebook. Lower is better; 0 is a perfect win.
+ * Returned as the raw label for display.
+ */
+export function kitesScoreLabel(score: number): string {
+  if (score === 0) return "You've blown everyone away!";
+  if (score <= 6) return 'Flying high!';
+  if (score <= 15) return "You're lifting people's spirits.";
+  if (score <= 20) return 'Your kites are starting to flop out — keep at it.';
+  if (score <= 39) return 'A slight breeze... warming up.';
+  return 'No wind in sight.';
+}

--- a/shared/kites/deck.test.ts
+++ b/shared/kites/deck.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { createKitesDeck, dealKitesCards, shuffleKitesDeck } from './deck';
+import { KITES_DECK_SIZE } from './constants';
+import { validateFlipChoice } from './game-logic';
+
+describe('kites deck', () => {
+  it('builds a deck with the configured total card count', () => {
+    const deck = createKitesDeck();
+    expect(deck.length).toBe(KITES_DECK_SIZE);
+  });
+
+  it('has unique card ids', () => {
+    const deck = createKitesDeck();
+    const ids = new Set(deck.map((c) => c.id));
+    expect(ids.size).toBe(deck.length);
+  });
+
+  it('every card has 1 or 2 symbols', () => {
+    for (const c of createKitesDeck()) {
+      expect(c.symbols.length === 1 || c.symbols.length === 2).toBe(true);
+    }
+  });
+
+  it('shuffle preserves cards', () => {
+    const deck = createKitesDeck();
+    const ids = new Set(deck.map((c) => c.id));
+    const shuffled = shuffleKitesDeck([...deck]);
+    expect(new Set(shuffled.map((c) => c.id))).toEqual(ids);
+  });
+
+  it('deal splits the deck correctly', () => {
+    const deck = createKitesDeck();
+    const { dealt, remaining } = dealKitesCards(deck, 5);
+    expect(dealt.length).toBe(5);
+    expect(remaining.length).toBe(deck.length - 5);
+  });
+});
+
+describe('validateFlipChoice', () => {
+  it('accepts matching color for single-symbol card', () => {
+    expect(validateFlipChoice(['red'], ['red'])).toBeNull();
+  });
+
+  it('accepts white for single-symbol card', () => {
+    expect(validateFlipChoice(['blue'], ['white'])).toBeNull();
+  });
+
+  it('rejects unrelated color for single-symbol card', () => {
+    expect(validateFlipChoice(['red'], ['blue'])).not.toBeNull();
+  });
+
+  it('accepts both matching colors for double-symbol card', () => {
+    expect(validateFlipChoice(['red', 'blue'], ['blue', 'red'])).toBeNull();
+  });
+
+  it('rejects white substitution for double-symbol card', () => {
+    expect(validateFlipChoice(['red', 'blue'], ['red', 'white'])).not.toBeNull();
+  });
+
+  it('rejects wrong count', () => {
+    expect(validateFlipChoice(['red'], ['red', 'red'])).not.toBeNull();
+    expect(validateFlipChoice(['red', 'blue'], ['red'])).not.toBeNull();
+  });
+});

--- a/shared/kites/deck.ts
+++ b/shared/kites/deck.ts
@@ -1,0 +1,62 @@
+import type { KitesCard, KitesCardColor } from './types';
+import {
+  KITES_DECK_SIZE,
+  KITES_DOUBLE_COUNTS,
+  KITES_SINGLE_COUNTS,
+} from './constants';
+
+/** Build the unshuffled 53-card deck. */
+export function createKitesDeck(): KitesCard[] {
+  const cards: KitesCard[] = [];
+  let idx = 0;
+
+  for (const [color, count] of Object.entries(KITES_SINGLE_COUNTS)) {
+    for (let i = 0; i < count; i++) {
+      cards.push({
+        id: `s-${color}-${i}`,
+        symbols: [color as KitesCardColor],
+      });
+      idx++;
+    }
+  }
+
+  for (const [pair, count] of Object.entries(KITES_DOUBLE_COUNTS)) {
+    const [a, b] = pair.split('-') as [KitesCardColor, KitesCardColor];
+    for (let i = 0; i < count; i++) {
+      cards.push({
+        id: `d-${pair}-${i}`,
+        symbols: [a, b],
+      });
+      idx++;
+    }
+  }
+
+  if (cards.length !== KITES_DECK_SIZE) {
+    throw new Error(
+      `Kites deck size mismatch: expected ${KITES_DECK_SIZE}, got ${cards.length}`,
+    );
+  }
+  void idx;
+  return cards;
+}
+
+/** Fisher-Yates shuffle. Mutates the array and returns it for convenience. */
+export function shuffleKitesDeck(cards: KitesCard[]): KitesCard[] {
+  for (let i = cards.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [cards[i], cards[j]] = [cards[j], cards[i]];
+  }
+  return cards;
+}
+
+/** Deal `n` cards from the top of the deck. Returns dealt + remaining. */
+export function dealKitesCards(
+  deck: KitesCard[],
+  n: number,
+): { dealt: KitesCard[]; remaining: KitesCard[] } {
+  const safeN = Math.min(n, deck.length);
+  return {
+    dealt: deck.slice(0, safeN),
+    remaining: deck.slice(safeN),
+  };
+}

--- a/shared/kites/firestore-paths.ts
+++ b/shared/kites/firestore-paths.ts
@@ -1,0 +1,14 @@
+/** Firestore path helpers for Kites docs. Mirrors shared/core/firestore-paths.ts. */
+
+export function kitesGameDoc(roomId: string): string {
+  return `kitesGames/${roomId}`;
+}
+
+export function kitesHandDoc(uid: string, roomId: string): string {
+  return `kitesGames/${roomId}/hands/${uid}`;
+}
+
+/** Single deck doc per room (shared draw pile, no per-player decks). */
+export function kitesDeckDoc(roomId: string): string {
+  return `kitesGames/${roomId}/deck/main`;
+}

--- a/shared/kites/game-logic.ts
+++ b/shared/kites/game-logic.ts
@@ -1,0 +1,71 @@
+import type { KitesColor, KitesGameState, KitesTimer } from './types';
+
+/**
+ * Compute the wall-clock time at which a flowing timer will run out.
+ * Returns Infinity if the timer is paused (flippedAt === null).
+ */
+export function timerExpiresAt(timer: KitesTimer): number {
+  if (timer.flippedAt === null) return Infinity;
+  return timer.flippedAt + timer.durationMs;
+}
+
+/** Find the soonest-expiring timer in a flowing state. */
+export function nextTimerToExpire(
+  game: KitesGameState,
+): { timer: KitesTimer; expiresAt: number } | null {
+  let best: { timer: KitesTimer; expiresAt: number } | null = null;
+  for (const t of game.timers) {
+    const exp = timerExpiresAt(t);
+    if (exp === Infinity) continue;
+    if (best === null || exp < best.expiresAt) {
+      best = { timer: t, expiresAt: exp };
+    }
+  }
+  return best;
+}
+
+/**
+ * Compute total cards remaining (drawPileSize + sum of hand sizes).
+ * Used to score the run when a timer expires.
+ */
+export function cardsRemaining(game: KitesGameState): number {
+  let sum = game.drawPileSize;
+  for (const p of Object.values(game.players)) sum += p.handSize;
+  return sum;
+}
+
+/**
+ * Validate a player's flip choice for a played card.
+ *
+ * Rules:
+ *  - For a 2-symbol card, the player must flip the two matching colored timers.
+ *  - For a 1-symbol card, the player must flip exactly one timer that is
+ *    either the matching color OR the white timer.
+ *
+ * Returns null if valid, or a string error reason if invalid.
+ */
+export function validateFlipChoice(
+  cardSymbols: KitesColor[],
+  flipChoice: KitesColor[],
+): string | null {
+  if (flipChoice.length !== cardSymbols.length) {
+    return `Must flip ${cardSymbols.length} timer(s) for this card.`;
+  }
+
+  if (cardSymbols.length === 2) {
+    const sortedCard = [...cardSymbols].sort();
+    const sortedChoice = [...flipChoice].sort();
+    if (sortedCard[0] !== sortedChoice[0] || sortedCard[1] !== sortedChoice[1]) {
+      return 'Flip choice must match both colored symbols on this card.';
+    }
+    return null;
+  }
+
+  // Single-symbol card: choice must be the matching color or white.
+  const sym = cardSymbols[0];
+  const choice = flipChoice[0];
+  if (choice !== sym && choice !== 'white') {
+    return `Single-symbol card can only flip the ${sym} timer or the white timer.`;
+  }
+  return null;
+}

--- a/shared/kites/schemas.ts
+++ b/shared/kites/schemas.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import type {
+  KitesCard,
+  KitesGameState,
+  KitesHandDoc,
+  KitesDeckDoc,
+} from './types';
+
+const KitesCardColorSchema = z.enum(['red', 'orange', 'yellow', 'blue', 'purple']);
+const KitesAnyColorSchema = z.enum(['red', 'orange', 'yellow', 'white', 'blue', 'purple']);
+
+export const KitesCardSchema = z.object({
+  id: z.string(),
+  symbols: z.array(KitesCardColorSchema).min(1).max(2),
+});
+
+const KitesTimerSchema = z.object({
+  color: KitesAnyColorSchema,
+  durationMs: z.number().int().positive(),
+  flippedAt: z.number().nullable(),
+});
+
+const KitesPlayerSchema = z.object({
+  uid: z.string(),
+  displayName: z.string(),
+  handSize: z.number().int().min(0),
+  disconnected: z.boolean(),
+  isBot: z.boolean().optional(),
+});
+
+const KitesPlayedCardSchema = z.object({
+  id: z.string(),
+  uid: z.string(),
+  symbols: z.array(KitesCardColorSchema).min(1).max(2),
+  seq: z.number().int().min(0),
+});
+
+export const KitesGameStateSchema = z.object({
+  gameId: z.string(),
+  gameType: z.literal('kites'),
+  phase: z.enum(['lobby', 'playing', 'won', 'lost']),
+  hostUid: z.string(),
+  players: z.record(z.string(), KitesPlayerSchema),
+  playerOrder: z.array(z.string()),
+  timers: z.array(KitesTimerSchema),
+  drawPileSize: z.number().int().min(0),
+  recentPlays: z.array(KitesPlayedCardSchema),
+  totalPlayed: z.number().int().min(0),
+  endedAt: z.number().nullable(),
+  finalScore: z.number().nullable(),
+  endReason: z.enum(['win', 'timer_expired']).nullable(),
+  expiredTimerColor: KitesAnyColorSchema.nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const KitesHandDocSchema = z.object({
+  cards: z.array(KitesCardSchema),
+});
+
+export const KitesDeckDocSchema = z.object({
+  cards: z.array(KitesCardSchema),
+});
+
+export function parseKitesGameState(data: unknown): KitesGameState {
+  return KitesGameStateSchema.parse(data) as unknown as KitesGameState;
+}
+
+export function parseKitesHandDoc(data: unknown): KitesHandDoc {
+  return KitesHandDocSchema.parse(data) as unknown as KitesHandDoc;
+}
+
+export function parseKitesDeckDoc(data: unknown): KitesDeckDoc {
+  return KitesDeckDocSchema.parse(data) as unknown as KitesDeckDoc;
+}
+
+export function parseKitesCard(data: unknown): KitesCard {
+  return KitesCardSchema.parse(data) as unknown as KitesCard;
+}

--- a/shared/kites/types.ts
+++ b/shared/kites/types.ts
@@ -1,0 +1,99 @@
+// Kites: cooperative real-time game.
+// Players play kite cards from their hands; each card flips one or more sand
+// timers. The team loses if any timer runs out, wins when all cards are played.
+
+export const KitesColor = {
+  Red: 'red',
+  Orange: 'orange',
+  Yellow: 'yellow',
+  White: 'white',
+  Blue: 'blue',
+  Purple: 'purple',
+} as const;
+export type KitesColor = (typeof KitesColor)[keyof typeof KitesColor];
+
+/** The 5 colors that appear on Kite cards. White is timer-only. */
+export type KitesCardColor = Exclude<KitesColor, 'white'>;
+
+export const KitesPhase = {
+  Lobby: 'lobby',
+  Playing: 'playing',
+  Won: 'won',
+  Lost: 'lost',
+} as const;
+export type KitesPhase = (typeof KitesPhase)[keyof typeof KitesPhase];
+
+/** A single kite card. Cards have 1 or 2 colored symbols. */
+export interface KitesCard {
+  /** Unique id within the deck — used for stable references. */
+  id: string;
+  /** 1 = single-symbol (can also flip white timer); 2 = double-symbol. */
+  symbols: KitesCardColor[];
+}
+
+/** A sand timer. Server-authoritative; clients compute remaining time. */
+export interface KitesTimer {
+  color: KitesColor;
+  /** Total sand duration in ms. */
+  durationMs: number;
+  /**
+   * Wall-clock timestamp when the timer was last flipped (sand reset to full).
+   * Remaining time = durationMs - (now - flippedAt).
+   * `null` means the timer is on its side (paused / not yet started).
+   */
+  flippedAt: number | null;
+}
+
+export interface KitesPlayer {
+  uid: string;
+  displayName: string;
+  /** Cards currently in this player's hand. Subcollection holds the cards. */
+  handSize: number;
+  disconnected: boolean;
+  isBot?: boolean;
+}
+
+/** A card played to the table (face-up in front of a player). */
+export interface KitesPlayedCard {
+  id: string;
+  uid: string;
+  symbols: KitesCardColor[];
+  /** Sequence number — strictly increasing to determine display order. */
+  seq: number;
+}
+
+export interface KitesGameState {
+  gameId: string;
+  gameType: 'kites';
+  phase: KitesPhase;
+  hostUid: string;
+  players: Record<string, KitesPlayer>;
+  /** Order of active players. Late joiners (post-start) are not added. */
+  playerOrder: string[];
+  timers: KitesTimer[];
+  drawPileSize: number;
+  /** Most-recent N played cards (capped to keep doc size sane). */
+  recentPlays: KitesPlayedCard[];
+  /** Total cards played so far this game (used for seq + UI stats). */
+  totalPlayed: number;
+  /** Set when phase enters Won/Lost. */
+  endedAt: number | null;
+  /** Final score (lower is better). Cards remaining when game ends. */
+  finalScore: number | null;
+  /** Reason for ending in lost state. */
+  endReason: 'win' | 'timer_expired' | null;
+  /** Color of the timer that ran out, when endReason === 'timer_expired'. */
+  expiredTimerColor: KitesColor | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/** Subcollection: kitesGames/{roomId}/hands/{uid} */
+export interface KitesHandDoc {
+  cards: KitesCard[];
+}
+
+/** Subcollection (server-only): kitesGames/{roomId}/deck/main */
+export interface KitesDeckDoc {
+  cards: KitesCard[];
+}


### PR DESCRIPTION
Implements Kites alongside Pineapple Poker, reusing the auth/room/lobby
multiplayer pattern but with isolated state. Kites lives in its own
Firestore collection (kitesGames/) with its own Cloud Functions, dealer
listener, types, schemas, and React components.

- shared/kites/: types, schemas, deck (53 cards, 5 colors), constants,
  game-logic helpers, deck unit tests (11 tests passing)
- functions/src/kites-actions.ts: kitesJoinGame/Leave/Start/PlayCard/PlayAgain
- dealer/src/kites/: KitesDealer arms a single setTimeout for the
  soonest-expiring sand timer per room, transitions to Lost on expiry
- frontend/src/components/kites/: KitesRoomSelector, KitesLobby,
  KitesGamePage, KitesSandTimer (animated sand drain), KitesCardView
- App.tsx routes to KitesApp when ?game=kites is set; RoomSelector links
  out to Kites; Kites lobby links back to Pineapple
- firestore.rules: mirror Pineapple access pattern for kitesGames