### PR TITLE
feat(placement): unmissable low-time warning

### DIFF
--- a/frontend/src/components/mobile/MobileGamePage.tsx
+++ b/frontend/src/components/mobile/MobileGamePage.tsx
@@ -278,7 +278,7 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
         <div className="flex items-center gap-2">
           <span className="text-green-400 font-bold tracking-wider">{roomId}</span>
           {showTimer && (
-            <span className={`font-bold ${countdown < 10 ? 'text-red-400' : 'text-yellow-400'}`}>
+            <span className={`font-bold ${countdown <= 10 ? 'text-red-400 animate-pulse text-sm' : 'text-yellow-400'}`}>
               {countdown}s
             </span>
           )}
@@ -384,6 +384,14 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
               />
             )}
           </div>
+
+          {/* Low-time warning — placement is easy to lose track of; make the
+              impending auto-place unmissable when the player still has cards. */}
+          {showTimer && countdown > 0 && countdown <= 10 && !isObserver && hand.length > 0 && !submitting && (
+            <div className="bg-red-700 text-white text-center text-xs font-bold py-1 animate-pulse flex-shrink-0">
+              ⏰ {countdown}s left — place your cards!
+            </div>
+          )}
 
           {/* Hand area */}
           <MobileHandArea


### PR DESCRIPTION
Playtest item: *"players didn't realize they were timing out until cards got auto-placed."* The countdown was a tiny number in the header corner.

Now, when **≤10s remain and you still have cards to place**, a pulsing red banner appears right above your hand — `⏰ Ns left — place your cards!` — and the header timer pulses + enlarges. Only shows for active players who haven't finished placing (no nag once you're done or if you're observing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)