### PR TITLE
feat(run-mode): credit five-of-a-kind charms + first run-mode e2e

### DIFF
--- a/e2e/run-mode.spec.ts
+++ b/e2e/run-mode.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupTwoPlayerGame, playFullRound } from './helpers/game-setup';
+import { T_JOIN } from './helpers/timeouts';
+
+/** Draft the first offered charm + mutation (handling a suit target if asked). */
+async function draftCharmAndMutation(page: Page) {
+  await page.locator('[data-testid^="charm-option-"]').first().waitFor({ timeout: T_JOIN });
+  await page.locator('[data-testid^="charm-option-"]').first().click();
+  await page.locator('[data-testid^="mutation-option-"]').first().click();
+  // Some mutations (Suit Purge / Mono Suit) need a suit — pick one if asked.
+  const suit = page.locator('[data-testid^="suit-"]').first();
+  if (await suit.isVisible({ timeout: 1000 }).catch(() => false)) {
+    await suit.click();
+  }
+}
+
+test('Pineapple Run: enable, play a round, draft charm + mutation, advance', async ({ browser }) => {
+  test.setTimeout(240_000);
+  const { alice, bob, cleanup } = await setupTwoPlayerGame(browser);
+
+  // Host switches to Pineapple Run, then starts the run.
+  await alice.getByRole('button', { name: /Pineapple Run/ }).click();
+  await alice.getByTestId('start-match-button').click();
+
+  // Round 1 plays on a normal deck (mutations kick in from round 2).
+  await playFullRound(alice, bob);
+
+  // Between rounds, run mode shows the charm/mutation draft (not a results overlay).
+  await draftCharmAndMutation(alice);
+  await draftCharmAndMutation(bob);
+
+  // The run advances to round 2 and deals again (mutated decks must still deal).
+  await expect(alice.getByTestId('phase-label')).toContainText('R2', { timeout: T_JOIN });
+  await expect(alice.getByTestId('phase-label')).toContainText('initial_deal', { timeout: T_JOIN });
+  await alice.getByTestId('hand-card-0').waitFor({ timeout: T_JOIN });
+
+  await cleanup();
+});

--- a/frontend/src/components/CharmPickPage.tsx
+++ b/frontend/src/components/CharmPickPage.tsx
@@ -288,6 +288,7 @@ export function CharmPickPage({ gameState, uid, roomId, onLeaveRoom }: CharmPick
                   return (
                     <button
                       key={cid}
+                      data-testid={`charm-option-${cid}`}
                       onClick={() => handlePickCharm(cid)}
                       disabled={pickingCharm || !!myCharmPick}
                       className={`w-full text-left border p-2 transition-colors ${
@@ -331,6 +332,7 @@ export function CharmPickPage({ gameState, uid, roomId, onLeaveRoom }: CharmPick
                   return (
                     <div key={mid}>
                       <button
+                        data-testid={`mutation-option-${mid}`}
                         onClick={() => handlePickMutation(mid)}
                         disabled={pickingMutation || !!myMutationPick}
                         className={`w-full text-left border p-2 transition-colors ${
@@ -363,6 +365,7 @@ export function CharmPickPage({ gameState, uid, roomId, onLeaveRoom }: CharmPick
                           {SUIT_OPTIONS.map((opt) => (
                             <button
                               key={opt.suit}
+                              data-testid={`suit-${opt.suit}`}
                               onClick={() => handlePickMutation(mid, opt.suit)}
                               disabled={pickingMutation}
                               className={`px-3 py-2 text-xl ${opt.color} bg-gray-800 border border-gray-700 hover:border-amber-500 active:bg-amber-900/30 rounded`}

--- a/shared/game-logic/charms.test.ts
+++ b/shared/game-logic/charms.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { Rank, Suit } from '../core/types';
+import type { Board, Card } from '../core/types';
+import { CHARMS, foulShieldReduction } from './charms';
+
+const c = (rank: number, suit: Suit): Card => ({ rank: rank as Card['rank'], suit });
+const five = (rank: number): Card[] => [
+  c(rank, Suit.Spades), c(rank, Suit.Hearts), c(rank, Suit.Diamonds),
+  c(rank, Suit.Clubs), c(rank, Suit.Spades),
+];
+
+describe('charms: run-mode five-of-a-kind rows are credited', () => {
+  it('middle_mastery (two-pair-or-better) fires for a five-of-a-kind middle', () => {
+    const board: Board = { top: [], middle: five(Rank.Seven), bottom: [] };
+    // Pre-fix this read as High Card via the core evaluator → 0.
+    expect(CHARMS.middle_mastery.bonus(board)).toBe(15);
+  });
+
+  it('brick_bottom (straight-or-better) fires for a five-of-a-kind bottom', () => {
+    const board: Board = { top: [], middle: [], bottom: five(Rank.Ace) };
+    expect(CHARMS.brick_bottom.bonus(board)).toBe(15);
+  });
+
+  it('straight_edge does NOT count a five-of-a-kind as a straight', () => {
+    const board: Board = { top: [], middle: five(Rank.Nine), bottom: [] };
+    expect(CHARMS.straight_edge.bonus(board)).toBe(0);
+  });
+});
+
+describe('charms: foul shield', () => {
+  it('sums foul_shield reductions', () => {
+    expect(foulShieldReduction(['foul_shield'])).toBe(6);
+    expect(foulShieldReduction([])).toBe(0);
+    expect(foulShieldReduction(['pair_pride'])).toBe(0);
+  });
+});

--- a/shared/game-logic/charms.ts
+++ b/shared/game-logic/charms.ts
@@ -10,10 +10,11 @@
  */
 import type { Board, Card, CharmId } from '../core/types';
 import { HandRank, ThreeCardHandRank, Rank } from '../core/types';
-import {
-  evaluate3CardHand,
-  evaluate5CardHand,
-} from './hand-evaluation';
+import { evaluate3CardHand } from './hand-evaluation';
+// Run-aware evaluator: charms only apply in Pineapple Run, where a row can be a
+// five-of-a-kind. The core evaluator reads those as High Card and would silently
+// under-credit "X or better" charms.
+import { evaluateRunRow } from './run-evaluation';
 import { isFoul } from './scoring';
 
 export interface CharmDef {
@@ -69,12 +70,12 @@ function topIsPairOrBetter(board: Board): boolean {
 
 function middleIsTwoPairOrBetter(board: Board): boolean {
   if (board.middle.length !== 5) return false;
-  return evaluate5CardHand(board.middle).handRank >= HandRank.TwoPair;
+  return evaluateRunRow(board.middle).handRank >= HandRank.TwoPair;
 }
 
 function bottomIsStraightOrBetter(board: Board): boolean {
   if (board.bottom.length !== 5) return false;
-  return evaluate5CardHand(board.bottom).handRank >= HandRank.Straight;
+  return evaluateRunRow(board.bottom).handRank >= HandRank.Straight;
 }
 
 function rowFlushes(board: Board): number {
@@ -87,11 +88,11 @@ function rowFlushes(board: Board): number {
 function rowStraights(board: Board): number {
   let n = 0;
   if (board.middle.length === 5) {
-    const r = evaluate5CardHand(board.middle).handRank;
+    const r = evaluateRunRow(board.middle).handRank;
     if (r === HandRank.Straight || r === HandRank.StraightFlush) n++;
   }
   if (board.bottom.length === 5) {
-    const r = evaluate5CardHand(board.bottom).handRank;
+    const r = evaluateRunRow(board.bottom).handRank;
     if (r === HandRank.Straight || r === HandRank.StraightFlush) n++;
   }
   return n;


### PR DESCRIPTION
Two Pineapple Run improvements:

**1. Charm correctness (the caveat from the run-mode fork).** The "X or better" charms — Middle Mastery, Brick Bottom, Straight Edge — evaluated rows with the *core* evaluator, which reads a run-mode **five-of-a-kind as High Card** and silently under-credited them. They now use the run-aware `evaluateRunRow`. New `charms.test.ts` proves a five-of-a-kind middle/bottom is credited (and that a five-of-a-kind is correctly *not* counted as a straight).

**2. First e2e coverage for Pineapple Run (it had zero).** `run-mode.spec.ts`: enable run mode, play a round, draft a charm + mutation as both players, and confirm the run advances to round 2 dealing the mutated decks. Required adding `data-testid`s to `CharmPickPage` (`charm-option-*`, `mutation-option-*`, `suit-*`) — the e2e blocker the audit flagged.

## Verification
All 3 builds + lint; 109 shared unit tests; full e2e suite **9/9 green** locally (run-mode spec verified 2× in isolation, ~8s each).

🤖 Generated with [Claude Code](https://claude.com/claude-code)