### PR TITLE
feat(run-mode): more charms + deck mutations

### DIFF
--- a/shared/game-logic/charms.test.ts
+++ b/shared/game-logic/charms.test.ts
@@ -34,3 +34,34 @@ describe('charms: foul shield', () => {
     expect(foulShieldReduction(['pair_pride'])).toBe(0);
   });
 });
+
+describe('charms: new run-mode content', () => {
+  it('full_boat awards 25 for a full house row', () => {
+    const board: Board = {
+      top: [],
+      middle: [],
+      bottom: [c(Rank.Seven, Suit.Spades), c(Rank.Seven, Suit.Hearts), c(Rank.Seven, Suit.Diamonds), c(Rank.King, Suit.Spades), c(Rank.King, Suit.Hearts)],
+    };
+    expect(CHARMS.full_boat.bonus(board)).toBe(25);
+  });
+
+  it('quad_squad awards 40 for a four-of-a-kind row, full_boat also fires', () => {
+    const board: Board = {
+      top: [],
+      middle: [],
+      bottom: [c(Rank.Nine, Suit.Spades), c(Rank.Nine, Suit.Hearts), c(Rank.Nine, Suit.Diamonds), c(Rank.Nine, Suit.Clubs), c(Rank.Two, Suit.Spades)],
+    };
+    expect(CHARMS.quad_squad.bonus(board)).toBe(40);
+    expect(CHARMS.full_boat.bonus(board)).toBe(25); // quads >= full house
+  });
+
+  it('low_baller awards +2 per card ranked 5 or lower', () => {
+    const board: Board = {
+      top: [c(Rank.Two, Suit.Spades), c(Rank.Three, Suit.Hearts), c(Rank.Four, Suit.Diamonds)],
+      middle: [c(Rank.Five, Suit.Spades), c(Rank.Five, Suit.Hearts), c(Rank.King, Suit.Diamonds), c(Rank.Ace, Suit.Spades), c(Rank.Queen, Suit.Clubs)],
+      bottom: [],
+    };
+    // ≤5 cards: 2,3,4,5,5 = 5 → 10
+    expect(CHARMS.low_baller.bonus(board)).toBe(10);
+  });
+});

--- a/shared/game-logic/charms.ts
+++ b/shared/game-logic/charms.ts
@@ -109,6 +109,23 @@ function hasRoyals(board: Board): boolean {
   return false;
 }
 
+/** True if the middle or bottom (complete) row is at least `minRank` strong. */
+function anyFiveCardRowAtLeast(board: Board, minRank: number): boolean {
+  for (const cards of [board.middle, board.bottom]) {
+    if (cards.length === 5 && evaluateRunRow(cards).handRank >= minRank) return true;
+  }
+  return false;
+}
+
+/** Count cards on the board ranked at or below `maxRank`. */
+function countRankAtMost(board: Board, maxRank: number): number {
+  let n = 0;
+  for (const row of [board.top, board.middle, board.bottom]) {
+    for (const c of row) if (c.rank <= maxRank) n++;
+  }
+  return n;
+}
+
 // ---- Charm catalog ----
 
 export const CHARMS: Record<CharmId, CharmDef> = {
@@ -193,6 +210,27 @@ export const CHARMS: Record<CharmId, CharmDef> = {
     emoji: '🥇',
     description: '+5 for each Ace on your board.',
     bonus: (b) => 5 * countRankOnBoard(b, Rank.Ace),
+  },
+  full_boat: {
+    id: 'full_boat',
+    name: 'Full Boat',
+    emoji: '🚤',
+    description: '+25 if any 5-card row is a full house or better.',
+    bonus: (b) => (anyFiveCardRowAtLeast(b, HandRank.FullHouse) ? 25 : 0),
+  },
+  quad_squad: {
+    id: 'quad_squad',
+    name: 'Quad Squad',
+    emoji: '🎰',
+    description: '+40 if any 5-card row is four of a kind or better.',
+    bonus: (b) => (anyFiveCardRowAtLeast(b, HandRank.FourOfAKind) ? 40 : 0),
+  },
+  low_baller: {
+    id: 'low_baller',
+    name: 'Low Baller',
+    emoji: '🎳',
+    description: '+2 for each 5-or-lower card on your board.',
+    bonus: (b) => 2 * countRankAtMost(b, Rank.Five),
   },
   foul_shield: {
     id: 'foul_shield',

--- a/shared/game-logic/mutations.test.ts
+++ b/shared/game-logic/mutations.test.ts
@@ -24,6 +24,11 @@ describe('deckSizeAfter (exact stacked sizing)', () => {
     // every card is now a heart; purging hearts removes all 52 -> 0 in the worst case
     expect(deckSizeAfter(owned, 'suit_purge')).toBe(0);
   });
+
+  it('sizes the new removal mutations correctly', () => {
+    expect(deckSizeAfter([], 'bottom_heavy')).toBe(36); // ranks 2-10 × 4 suits
+    expect(deckSizeAfter([], 'royal_court')).toBe(24); // ranks 9-A × 4 suits
+  });
 });
 
 describe('rollMutationOptions (deck-size floor, no unsafe fallback)', () => {

--- a/shared/game-logic/mutations.ts
+++ b/shared/game-logic/mutations.ts
@@ -191,6 +191,22 @@ export const MUTATIONS: Record<MutationId, MutationDef> = {
     },
     approxDeckSize: 60,
   },
+  bottom_heavy: {
+    id: 'bottom_heavy',
+    name: 'Bottom Heavy',
+    emoji: '🪙',
+    description: 'Remove every face card (J, Q, K, A). Small-ball poker.',
+    apply: (deck) => deck.filter((c) => c.rank < R.Jack),
+    approxDeckSize: 36,
+  },
+  royal_court: {
+    id: 'royal_court',
+    name: 'Royal Court',
+    emoji: '🏰',
+    description: 'Remove every card below 9. Monsters only.',
+    apply: (deck) => deck.filter((c) => c.rank >= R.Nine),
+    approxDeckSize: 24,
+  },
 };
 
 export const MUTATION_IDS: MutationId[] = Object.keys(MUTATIONS);


### PR DESCRIPTION
More variety for Pineapple Run (the roguelike thrives on it). Catalog-driven, so they show up in the draft UI automatically.

**New charms:** Full Boat (+25 if a 5-card row is a full house+), Quad Squad (+40 if a row is quads+), Low Baller (+2 per board card ranked ≤5 — pairs with Bottom Feeder / Cull).
**New mutations:** Bottom Heavy (remove all face cards → 36-card deck), Royal Court (remove everything below 9 → 24-card deck).

The deck-size floor (`deckSizeAfter`) keeps the new removal mutations safe to stack. +4 unit tests (113 shared total); builds + lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)