### PR TITLE
perf(frontend): split Firebase + React into cacheable vendor chunks

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,4 +17,18 @@ export default defineConfig({
       '@shared': path.resolve(__dirname, '../shared'),
     },
   },
+  build: {
+    rollupOptions: {
+      output: {
+        // Split rarely-changing vendor code (Firebase SDK, React) into their own
+        // chunks so they cache across deploys and the app chunk shrinks.
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            if (id.includes('/firebase/') || id.includes('/@firebase/')) return 'firebase'
+            if (id.includes('/react') || id.includes('/scheduler/')) return 'react-vendor'
+          }
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
The app shipped as a single **733 KB** JS chunk (gzip 225 KB), fully re-downloaded on every deploy. Added rollup `manualChunks`:

| | before | after |
|---|---|---|
| app (`index`) | 733 KB | **187 KB** (gzip 55 KB) |
| `react-vendor` | — | 193 KB (gzip 60 KB) |
| `firebase` | — | 351 KB (gzip 110 KB) |

Vendor chunks rarely change, so browsers keep them cached across deploys and only re-fetch the small app chunk. Also clears the 500 KB chunk-size warning. Lint passes; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)