### PR TITLE
fix(core): turn-timer dropdown + scoring breakdown that sums

### DIFF
--- a/frontend/src/components/Lobby.tsx
+++ b/frontend/src/components/Lobby.tsx
@@ -176,6 +176,8 @@ export function Lobby({ uid, displayName, setDisplayName, signIn, gameState, isI
                   <option value={30000}>30s</option>
                   <option value={45000}>45s</option>
                   <option value={60000}>60s</option>
+                  <option value={90000}>90s</option>
+                  <option value={120000}>120s</option>
                 </select>
               ) : (
                 <span className="text-gray-400">{turnTimeoutMs / 1000}s</span>

--- a/frontend/src/components/mobile/MobileRoundOverlay.tsx
+++ b/frontend/src/components/mobile/MobileRoundOverlay.tsx
@@ -1,6 +1,6 @@
 import type { GameState } from '@shared/core/types';
 import { compareRows } from '@shared/game-logic/hand-evaluation';
-import { calculateRoyalties } from '@shared/game-logic/scoring';
+import { scorePairwise } from '@shared/game-logic/scoring';
 import { formatScore } from '../../utils/scoring-display.ts';
 import { useScoreCountUp } from '../../hooks/useScoreCountUp.ts';
 
@@ -37,9 +37,6 @@ export function MobileRoundOverlay({ gameState, currentUid }: MobileRoundOverlay
   const opponents = gameState.playerOrder.filter(
     (u) => u !== currentUid && gameState.players[u],
   );
-
-  const boardComplete = (b: { top: unknown[]; middle: unknown[]; bottom: unknown[] }) =>
-    b.top.length === 3 && b.middle.length === 5 && b.bottom.length === 5;
 
   return (
     <div
@@ -105,30 +102,46 @@ export function MobileRoundOverlay({ gameState, currentUid }: MobileRoundOverlay
           {opponents.map((ouid) => {
             const opp = gameState.players[ouid];
             const oFouled = roundResults[ouid]?.fouled ?? false;
-            const playable = !myFouled && !oFouled && boardComplete(me.board) && boardComplete(opp.board);
+            // Use the SAME scorer the server used, so the parts always add up.
+            const pr = scorePairwise(currentUid, myFouled, me.board, ouid, oFouled, opp.board);
+            const fouled = myFouled || oFouled;
             return (
               <div key={ouid} className="flex items-center justify-between bg-gray-800/40 rounded px-2 py-1 gap-2">
-                <span className="text-gray-400 truncate">vs {opp.displayName}</span>
-                {playable ? (
-                  <span className="flex items-center gap-1 flex-shrink-0">
-                    <RowChip label="T" result={compareRows(me.board.top, opp.board.top, true)} />
-                    <RowChip label="M" result={compareRows(me.board.middle, opp.board.middle, false)} />
-                    <RowChip label="B" result={compareRows(me.board.bottom, opp.board.bottom, false)} />
-                    {(() => {
-                      const roy = calculateRoyalties(me.board).total - calculateRoyalties(opp.board).total;
-                      return roy !== 0 ? (
-                        <span className={roy > 0 ? 'text-green-300' : 'text-red-300'}>roy {formatScore(roy)}</span>
-                      ) : null;
-                    })()}
+                <span className="text-gray-400 truncate min-w-0">vs {opp.displayName}</span>
+                <span className="flex items-center gap-1.5 flex-shrink-0">
+                  {fouled ? (
+                    <span className="text-gray-500">{myFouled ? 'you fouled' : 'they fouled'}</span>
+                  ) : (
+                    <>
+                      <RowChip label="T" result={compareRows(me.board.top, opp.board.top, true)} />
+                      <RowChip label="M" result={compareRows(me.board.middle, opp.board.middle, false)} />
+                      <RowChip label="B" result={compareRows(me.board.bottom, opp.board.bottom, false)} />
+                      {pr.scoopBonus !== 0 && (
+                        <span className="text-yellow-300">scoop {formatScore(pr.scoopBonus)}</span>
+                      )}
+                      {pr.royalties !== 0 && (
+                        <span className={pr.royalties > 0 ? 'text-green-300' : 'text-red-300'}>
+                          roy {formatScore(pr.royalties)}
+                        </span>
+                      )}
+                    </>
+                  )}
+                  <span
+                    className={`font-bold tabular-nums ${
+                      pr.total > 0 ? 'text-green-300' : pr.total < 0 ? 'text-red-300' : 'text-gray-400'
+                    }`}
+                  >
+                    = {formatScore(pr.total)}
                   </span>
-                ) : (
-                  <span className="text-gray-500 flex-shrink-0">
-                    {myFouled ? 'you fouled' : oFouled ? `${opp.displayName} fouled` : '–'}
-                  </span>
-                )}
+                </span>
               </div>
             );
           })}
+          {opponents.length > 1 && (
+            <div className="text-right text-[10px] text-gray-500 pt-0.5">
+              total = your round {formatScore(myRoundScore)}
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/preview/mocks.ts
+++ b/frontend/src/preview/mocks.ts
@@ -1,6 +1,7 @@
 import type { Card, GameState, PlayerState, Board, RoundResult } from '@shared/core/types';
 import { Suit, Rank, GamePhase } from '@shared/core/types';
 import { ROUNDS_PER_MATCH, DEFAULT_MATCH_SETTINGS } from '@shared/core/constants';
+import { scoreAllPlayers } from '@shared/game-logic/scoring';
 
 // --- Seeded RNG for deterministic card generation ---
 
@@ -157,8 +158,8 @@ export function generateMockGameState(opts: MockOptions): GameState {
     const board = fillBoard(playerDeck, boardCardCount);
     const isFouled = i === 0 ? opts.fouled : false;
 
-    // Generate scores for overlays
-    const score = opts.overlay !== 'none' ? Math.floor(seededRng(300 + i)() * 20 - 10) : 0;
+    // Scores for result screens are derived from the boards below.
+    const score = 0;
 
     players[uid] = {
       uid,
@@ -169,6 +170,16 @@ export function generateMockGameState(opts: MockOptions): GameState {
       fouled: isFouled,
       score,
     };
+  }
+
+  // For result screens, derive scores from the actual boards via the real
+  // scorer so the overlay's numbers are internally consistent (hero, ranking,
+  // and the per-opponent breakdown all add up).
+  if (opts.overlay !== 'none') {
+    const boards = new Map(uids.map((u) => [u, players[u].board]));
+    const fouls = new Map(uids.map((u) => [u, players[u].fouled]));
+    const result = scoreAllPlayers(boards, fouls);
+    for (const ps of result.players) players[ps.uid].score = ps.netScore;
   }
 
   // Generate round results for overlays


### PR DESCRIPTION
Two playtest bugs from screenshots:

1. **Turn Timer dropdown broken** — default moved to 90s but the dropdown only went to 60s, so it showed a mismatched value. Added **90s + 120s** options.
2. **"Where it came from" didn't sum** — it showed row win/loss chips but omitted scoop/royalties and had no explicit total. Now computed with the **same `scorePairwise` the server uses**, showing rows + scoop + royalties + an explicit `= total` per opponent (plus a sum line for 3+ players). Verified in preview: `+6 vs Alice + +2 vs Bob = +8`.

Also fixed the preview mock to derive scores from the boards via the real scorer so overlay previews are internally consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)