### PR TITLE
Project setup: automated release notes, Dependabot, labels & templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: 🐛 Bug report
+description: Report a problem with the game or the codebase
+title: "[Bug]: "
+labels: ["type:bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Create a room…
+        2. On street 4…
+        3. See error
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Frontend (UI)
+        - Dealer / game engine
+        - Cloud Functions
+        - Shared game logic
+        - E2E / tests
+        - Infra / CI / deploy
+        - Not sure
+    validations:
+      required: false
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: Browser / device / OS, and whether it was local or production.
+      placeholder: e.g. Chrome 130, iPhone 14, production
+    validations:
+      required: false
+  - type: input
+    id: room
+    attributes:
+      label: Room code (if applicable)
+      placeholder: e.g. AB3KP9
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Console errors, dealer logs, or screenshots — drag & drop here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 📋 Roadmap
+    url: https://github.com/RobertCorey/pineapple-poker-v2/projects
+    about: See what's planned, in progress, and shipped.
+  - name: ▶ Play the game
+    url: https://pineapple-poker-8f3.web.app
+    about: Try Pineapple Poker in your browser.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: 💡 Feature request
+description: Suggest a new feature, improvement, or idea
+title: "[Feature]: "
+labels: ["type:feature"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do, or what's frustrating today?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Gameplay & rules
+        - Multiplayer & rooms
+        - UI / UX
+        - Dealer / game engine
+        - Infra / tooling
+        - Something else
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+<!--
+  Tip: use a Conventional Commit style title (feat:, fix:, perf:, docs:, chore:, refactor:)
+  — it drives the auto-generated release notes and the version bump.
+-->
+
+## Summary
+
+<!-- What does this change and why? -->
+
+## Changes
+
+-
+
+## Type of change
+
+- [ ] ✨ feat — new functionality
+- [ ] 🐛 fix — bug fix
+- [ ] ⚡ perf — performance
+- [ ] 📝 docs — documentation
+- [ ] 🧰 chore / refactor — maintenance
+
+## Checklist
+
+- [ ] `npm run lint` passes
+- [ ] Builds: `npm run build -w frontend && npm run build -w functions && npm run build -w dealer`
+- [ ] `npm run test:unit` passes
+- [ ] E2E (`npm test`) pass where relevant
+- [ ] Updated docs / CLAUDE.md if behavior changed
+
+<!-- Link issues this resolves, e.g. "Closes #123" -->
+Closes #

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # Root npm workspaces (frontend, functions, dealer, shared) — single lockfile
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      # Batch low-risk updates into one PR to cut noise
+      minor-and-patch:
+        update-types: ["minor", "patch"]
+
+  # Standalone bot package (not part of the workspaces)
+  - package-ecosystem: npm
+    directory: "/bot"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 3
+    labels: ["dependencies"]
+    commit-message:
+      prefix: chore
+
+  # Keep GitHub Actions versions fresh
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels: ["dependencies"]
+    commit-message:
+      prefix: ci

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,36 @@
+# Auto-applies area:* labels based on which files a PR touches.
+# Used by .github/workflows/labeler.yml (actions/labeler v5).
+
+"area:frontend":
+  - changed-files:
+      - any-glob-to-any-file: "frontend/**"
+
+"area:functions":
+  - changed-files:
+      - any-glob-to-any-file: "functions/**"
+
+"area:dealer":
+  - changed-files:
+      - any-glob-to-any-file: "dealer/**"
+
+"area:shared":
+  - changed-files:
+      - any-glob-to-any-file: "shared/**"
+
+"area:e2e":
+  - changed-files:
+      - any-glob-to-any-file: "e2e/**"
+
+"area:infra":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "firebase.json"
+          - "firestore.rules"
+          - "scripts/**"
+
+"type:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,46 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🚀 Features"
+    labels: ["type:feature"]
+  - title: "🐛 Bug Fixes"
+    labels: ["type:bug"]
+  - title: "⚡ Performance"
+    labels: ["type:perf"]
+  - title: "📝 Documentation"
+    labels: ["type:docs"]
+  - title: "🧰 Maintenance"
+    labels: ["type:chore", "type:refactor"]
+  - title: "⬆️ Dependencies"
+    labels: ["dependencies"]
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels: ["major"]
+  minor:
+    labels: ["type:feature"]
+  patch:
+    labels: ["type:bug", "type:perf", "type:docs", "type:chore", "type:refactor", "dependencies"]
+  default: patch
+exclude-labels:
+  - "skip-changelog"
+autolabeler:
+  - label: "type:feature"
+    title: ["/^feat(\\(.+\\))?:/"]
+  - label: "type:bug"
+    title: ["/^fix(\\(.+\\))?:/"]
+  - label: "type:perf"
+    title: ["/^perf(\\(.+\\))?:/"]
+  - label: "type:refactor"
+    title: ["/^refactor(\\(.+\\))?:/"]
+  - label: "type:docs"
+    title: ["/^docs(\\(.+\\))?:/"]
+  - label: "type:chore"
+    title: ["/^(chore|ci|build|test)(\\(.+\\))?:/"]
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/RobertCorey/pineapple-poker-v2/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,17 @@
+name: Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,46 @@
+name: Release Drafter
+
+on:
+  push:
+    branches: [main]
+  # pull_request_target (not pull_request) so the workflow + config are read
+  # from the default branch — avoids the "config must reside in default branch"
+  # error and is the recommended pattern for labelers (no PR code is executed).
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  # Keep the draft release notes up to date on every merge to main.
+  draft:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Best-effort: label PRs from their conventional-commit title so the notes
+  # group correctly. Non-blocking — never fails a PR.
+  autolabel:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+          disable-releaser: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Pineapple Poker
 
-Open Face Chinese Pineapple Poker — a multiplayer card game built with Firebase.
+Open Face Chinese Pineapple Poker — a real-time, multiplayer card game built with React + Firebase.
+
+[![CI](https://github.com/RobertCorey/pineapple-poker-v2/actions/workflows/ci.yml/badge.svg)](https://github.com/RobertCorey/pineapple-poker-v2/actions/workflows/ci.yml)
+[![Deploy](https://github.com/RobertCorey/pineapple-poker-v2/actions/workflows/deploy.yml/badge.svg)](https://github.com/RobertCorey/pineapple-poker-v2/actions/workflows/deploy.yml)
+[![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![Firebase](https://img.shields.io/badge/Firebase-Firestore_+_Functions-FFCA28?logo=firebase&logoColor=black)](https://firebase.google.com)
+[![Play](https://img.shields.io/badge/play-pineapple--poker--8f3.web.app-22c55e?logo=googlechrome&logoColor=white)](https://pineapple-poker-8f3.web.app)
+
+**[▶ Play](https://pineapple-poker-8f3.web.app)** · **[Roadmap](https://github.com/RobertCorey/pineapple-poker-v2/projects)** · **[Releases](https://github.com/RobertCorey/pineapple-poker-v2/releases)** · **[Issues](https://github.com/RobertCorey/pineapple-poker-v2/issues)**
 
 ## Stack
 
@@ -44,14 +53,13 @@ npm run dev
 npm run dealer
 ```
 
-Emulator ports: Auth 9099, Functions 5001, Firestore 8080, Hosting 5000, UI 4000.
+Emulator ports: Auth 9099, Functions 5001, Firestore 8080, Hosting 5050, UI 4000.
 
 ## Testing
 
-E2E tests require the emulators and dealer to be running:
-
 ```bash
-npm test
+npm run test:unit   # shared game logic + dealer unit tests (no emulators)
+npm test            # full Playwright E2E suite (needs emulators + dealer running)
 ```
 
 ## Building
@@ -67,12 +75,18 @@ npm run dealer:build       # Dealer
 - **Board**: 3 rows — top (3 cards), middle (5 cards), bottom (5 cards)
 - **Initial deal**: 5 cards, place all 5
 - **Streets 2-5**: Deal 3 cards, place 2, discard 1
+- **Match**: 3 rounds; highest cumulative score wins
 - **Foul**: Rows not in ascending strength (bottom >= middle > top) — penalty of 6 points per opponent
 - **Scoring**: Pairwise row comparisons (+1/-1 per row), scoop bonus (+3 for winning all 3 rows), plus royalty bonuses for strong rows (scored as a net differential between the two players; void when either fouls)
 
-## Game Modes
+## Project & contributing
 
-The host picks a mode in the lobby:
+This repo is set up to stay tidy and easy to follow:
 
-- **Classic OFC Pineapple** (default): 3-round match.
-- **Pineapple Run**: a 5-round single-player-style roguelike. Between rounds you draft a *charm* (score bonus) and a *deck mutation* (permanent change to your deck), which stack across the run.
+- **CI** runs lint, builds, unit tests, and the Playwright E2E suite on every PR (see the badges above).
+- **Roadmap** — what's planned / in progress lives on the [project board](https://github.com/RobertCorey/pineapple-poker-v2/projects).
+- **Releases** — [release notes](https://github.com/RobertCorey/pineapple-poker-v2/releases) are drafted automatically from merged PRs by [Release Drafter](.github/release-drafter.yml).
+- **Issues & PRs** use [templates](.github/ISSUE_TEMPLATE); PRs are auto-labeled by area, and **Conventional Commit** titles (`feat:`, `fix:`, `perf:`, `docs:`, `chore:`) drive the release notes and version bump.
+- **Dependencies** are kept current by [Dependabot](.github/dependabot.yml).
+
+See [`CLAUDE.md`](CLAUDE.md) for the full architecture, dev workflow, and CI/CD details.


### PR DESCRIPTION
Sets the repo up to run cleanly and stay organized — the engineering/project side, no marketing.

## What's in this PR (files)
- **Release Drafter** (`.github/release-drafter.yml` + workflow) — keeps a **draft GitHub Release** with grouped, auto-generated notes from merged PRs. Conventional-commit **autolabeler** + version resolver, so a `feat:`/`fix:` title lands in the right section and bumps the version.
- **Dependabot** (`.github/dependabot.yml`) — weekly npm updates for the workspaces + the `bot/` package, plus GitHub Actions; minor/patch grouped to reduce PR noise.
- **PR auto-labeler** (`.github/labeler.yml` + workflow) — applies `area:*` labels based on changed paths.
- **Issue forms** (bug report / feature request) + **PR template**.
- **README** — CI/Deploy/tech **badges**, **Roadmap/Releases** links, and a *Project & contributing* section. Also fixed two stale bits on `main`: the leftover **Pineapple Run** section (mode was removed in #64) and the **hosting port** (5000 → 5050).

## Applied live (can't live in a PR) — done separately
- **Labels**: `type:*`, `area:*`, `dependencies` (these back the labeler + release-notes grouping).
- **Project board**: a public roadmap (Backlog / Next / In progress / Done) with issues organized onto it.

## After merge
- Release Drafter starts maintaining a draft release — bump + publish in one click when you want to cut `v1.0.0`.
- New PRs get auto-labeled by area and feed the release notes.

## Notes
- CI already runs lint + builds + unit + Playwright e2e on every PR; the badges surface it.
- No changes to game code, the dealer, or deploy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)