### PR TITLE
feat(timer): replace numeric countdown with depleting timer bar

### DIFF
--- a/frontend/src/components/mobile/MobileGamePage.tsx
+++ b/frontend/src/components/mobile/MobileGamePage.tsx
@@ -4,7 +4,7 @@ import { useSoundEffects } from '../../audio/useSoundEffects.ts';
 import { useTickSound } from '../../audio/useTickSound.ts';
 import type { Card, Row, Board } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
-import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT } from '@shared/core/constants';
+import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT, DEFAULT_MATCH_SETTINGS } from '@shared/core/constants';
 import { isFoul } from '@shared/game-logic/scoring';
 import { placeCards, leaveGame } from '../../api.ts';
 import { trackEvent } from '../../firebase.ts';
@@ -17,6 +17,7 @@ import { MobileOpponentGrid } from './MobileOpponentGrid.tsx';
 import { MobileHandArea } from './MobileHandArea.tsx';
 import { MobileRoundOverlay } from './MobileRoundOverlay.tsx';
 import { MobileMatchOverlay } from './MobileMatchOverlay.tsx';
+import { TimerBar } from './TimerBar.tsx';
 
 const STREET_PHASES = new Set<string>([
   GamePhase.Street2,
@@ -273,11 +274,6 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
       <div className="border-b border-gray-700 px-2 py-1.5 flex items-center justify-between text-[10px] flex-shrink-0">
         <div className="flex items-center gap-2">
           <span className="text-green-400 font-bold tracking-wider">{roomId}</span>
-          {showTimer && (
-            <span className={`font-bold ${countdown <= 10 ? 'text-red-400 animate-pulse text-sm' : 'text-yellow-400'}`}>
-              {countdown}s
-            </span>
-          )}
         </div>
         <div className="flex items-center gap-2">
           <span className="text-gray-500" data-testid="phase-label">
@@ -299,6 +295,17 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
           </button>
         </div>
       </div>
+
+      {/* Turn timer: depleting bar under the header (replaces a numeric countdown).
+          The ≤10s warning banner below still spells out the seconds. */}
+      {showTimer && gameState.phaseDeadline != null && (
+        <TimerBar
+          deadline={gameState.phaseDeadline}
+          totalMs={gameState.settings?.turnTimeoutMs ?? DEFAULT_MATCH_SETTINGS.turnTimeoutMs}
+          urgent={countdown <= 10}
+          secondsLeft={countdown}
+        />
+      )}
 
       {/* Observer banner */}
       {isObserver && (

--- a/frontend/src/components/mobile/TimerBar.tsx
+++ b/frontend/src/components/mobile/TimerBar.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import type { CSSProperties } from 'react';
+
+interface TimerBarProps {
+  /** Epoch ms when the phase times out. */
+  deadline: number;
+  /** Full phase duration (settings.turnTimeoutMs) — the bar is full at totalMs remaining. */
+  totalMs: number;
+  /** Last-seconds state: recolor the bar red. */
+  urgent: boolean;
+  /** Whole seconds remaining, for the accessible label only. */
+  secondsLeft: number;
+}
+
+function computeAnim(deadline: number, totalMs: number) {
+  const remaining = Math.max(0, deadline - Date.now());
+  return { fraction: Math.min(1, remaining / totalMs), durationMs: remaining };
+}
+
+/**
+ * Depleting turn-timer bar. The fill starts at the fraction of phase time
+ * remaining and a CSS animation shrinks it to zero exactly at the deadline,
+ * so it stays smooth without per-frame re-renders.
+ */
+export function TimerBar({ deadline, totalMs, urgent, secondsLeft }: TimerBarProps) {
+  // Freeze the start fraction/duration per deadline (same adjust-during-render
+  // pattern as useCountdown): changing animation-duration mid-flight would make
+  // the playback position jump.
+  const [anim, setAnim] = useState(() => computeAnim(deadline, totalMs));
+  const [prevDeadline, setPrevDeadline] = useState(deadline);
+  if (prevDeadline !== deadline) {
+    setPrevDeadline(deadline);
+    setAnim(computeAnim(deadline, totalMs));
+  }
+
+  return (
+    <div
+      className="h-1 bg-gray-800 flex-shrink-0"
+      role="timer"
+      aria-label={`${secondsLeft} seconds remaining`}
+    >
+      <div
+        key={deadline}
+        className={`h-full timer-deplete ${urgent ? 'bg-red-500' : 'bg-yellow-400'}`}
+        style={{
+          transform: `scaleX(${anim.fraction})`,
+          '--timer-ms': `${anim.durationMs}ms`,
+        } as CSSProperties}
+      />
+    </div>
+  );
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -27,6 +27,18 @@
   animation: lp-glow 6s ease-in-out infinite;
 }
 
+/* ---- Turn timer bar ---- */
+/* Depletes left-to-right over the remaining phase time. The element sets
+   --timer-ms inline; the implicit `from` is its inline scaleX(fraction). */
+@keyframes timer-deplete {
+  to { transform: scaleX(0); }
+}
+.timer-deplete {
+  transform-origin: left;
+  animation: timer-deplete linear forwards;
+  animation-duration: var(--timer-ms, 0ms);
+}
+
 /* Accessibility: collapse all animations/transitions for users who ask the OS
    for reduced motion. Content stays visible — only the motion is removed.
    The .lp-* overrides pin entrance elements at full opacity (their keyframes
@@ -41,4 +53,7 @@
     scroll-behavior: auto !important;
   }
   .lp-fade-up, .lp-float, .lp-glow { animation: none; opacity: 1; }
+  /* The turn timer is essential information (time remaining), not decorative
+     motion — collapsing it would blank the only always-visible countdown. */
+  .timer-deplete { animation-duration: var(--timer-ms, 0ms) !important; }
 }


### PR DESCRIPTION
Closes #30.

## What

Replaces the numeric in-header countdown with a depleting timer bar, per the issue ("replace the countdown with an animation"). The sound half of #30 already shipped earlier as `useTickSound` (urgency-scaled ticks in the last 5s).

- **`TimerBar.tsx` (new)**: thin bar under the game header. The fill starts at the fraction of phase time remaining (`phaseDeadline` vs `settings.turnTimeoutMs`) and a CSS `scaleX` animation shrinks it to zero exactly at the deadline — smooth, GPU-friendly, zero per-frame re-renders. Start fraction/duration are frozen per deadline (adjust-during-render pattern, same as `useCountdown`) so the animation never recalculates mid-flight. Turns red in the last 10 seconds. `role="timer"` with a seconds label for screen readers.
- **`MobileGamePage.tsx`**: numeric `{countdown}s` span removed from the header; bar rendered under it during placement phases. The red ≤10s warning banner (which spells out the seconds) and the tick sound are unchanged.
- **`index.css`**: `timer-deplete` keyframes + an exemption from the global reduced-motion collapse — the timer is essential information (time remaining), not decorative motion; collapsing it would blank the only always-visible countdown.

## Testing

- `npm run lint`, `npm run build`, `npm run test:unit` clean locally.
- No E2E spec asserts on the old countdown text (checked); full suite runs in CI.
- Preview mocks already provide `settings` + a live `phaseDeadline`, so the bar renders in the preview harness.

https://claude.ai/code/session_0163gVKkvdVeyMJPaWYqUDom

---
_Generated by [Claude Code](https://claude.ai/code/session_0163gVKkvdVeyMJPaWYqUDom)_