### PR TITLE
feat(board): gold glow on rows that earn royalties

### DIFF
--- a/frontend/src/components/PlayerBoard.tsx
+++ b/frontend/src/components/PlayerBoard.tsx
@@ -27,11 +27,16 @@ function padRow(cards: Card[], size: number): (Card | null)[] {
   return result;
 }
 
-function rowLabel(
+interface RowEvalInfo {
+  label: string;
+  royalty: boolean;
+}
+
+function rowEval(
   row: 'top' | 'middle' | 'bottom',
   board: Board,
   royalties: { top: number; middle: number; bottom: number },
-): string | null {
+): RowEvalInfo | null {
   if (row === 'top') {
     if (board.top.length < 3) return null;
     const eval3 = evaluate3CardHand(board.top);
@@ -43,7 +48,7 @@ function rowLabel(
     }
     const name = THREE_CARD_HAND_RANK_NAMES[eval3.handRank];
     const pts = royalties.top;
-    return pts > 0 ? `${name} +${pts}` : name;
+    return { label: pts > 0 ? `${name} +${pts}` : name, royalty: pts > 0 };
   } else {
     const cards = row === 'middle' ? board.middle : board.bottom;
     if (cards.length < 5) return null;
@@ -51,7 +56,7 @@ function rowLabel(
     if (eval5.handRank === HandRank.HighCard) return null;
     const name = HAND_RANK_NAMES[eval5.handRank];
     const pts = royalties[row];
-    return pts > 0 ? `${name} +${pts}` : name;
+    return { label: pts > 0 ? `${name} +${pts}` : name, royalty: pts > 0 };
   }
 }
 
@@ -74,13 +79,13 @@ interface PlayerBoardProps {
   onUndoCard?: (row: Row, pendingIndex: number) => void;
 }
 
-function RowOverlay({ label, cardWidthPx }: { label: string; cardWidthPx: number }) {
+function RowOverlay({ label, royalty, cardWidthPx }: { label: string; royalty: boolean; cardWidthPx: number }) {
   return (
     <div
-      className="absolute inset-0 flex items-center justify-center bg-black/60 pointer-events-none rounded z-[5]"
+      className={`absolute inset-0 flex items-center justify-center bg-black/60 pointer-events-none rounded z-[5] ${royalty ? 'royalty-glow' : ''}`}
       style={{ fontSize: Math.max(10, Math.round(cardWidthPx * 0.28)) }}
     >
-      <span className="text-white font-bold drop-shadow-lg">{label}</span>
+      <span className={`font-bold drop-shadow-lg ${royalty ? 'text-yellow-300' : 'text-white'}`}>{label}</span>
     </div>
   );
 }
@@ -147,9 +152,9 @@ export function PlayerBoard({
 
   // Compute row labels (only when not fouled)
   const royalties = calculateRoyalties(board);
-  const topLabel = !fouled ? rowLabel('top', board, royalties) : null;
-  const middleLabel = !fouled ? rowLabel('middle', board, royalties) : null;
-  const bottomLabel = !fouled ? rowLabel('bottom', board, royalties) : null;
+  const topEval = !fouled ? rowEval('top', board, royalties) : null;
+  const middleEval = !fouled ? rowEval('middle', board, royalties) : null;
+  const bottomEval = !fouled ? rowEval('bottom', board, royalties) : null;
 
   return (
     <div
@@ -183,7 +188,7 @@ export function PlayerBoard({
         <div style={{ width: cardWidthPx }} />
         {topSlots.map((card, i) => renderSlot('top', Row.Top, board.top, card, i, `top-${i}`))}
         <div style={{ width: cardWidthPx }} />
-        {topLabel && <RowOverlay label={topLabel} cardWidthPx={cardWidthPx} />}
+        {topEval && <RowOverlay label={topEval.label} royalty={topEval.royalty} cardWidthPx={cardWidthPx} />}
       </div>
 
       {/* Middle row - 5 cards */}
@@ -194,7 +199,7 @@ export function PlayerBoard({
         style={{ gap, ...(fouled ? { transform: 'rotate(1deg)' } : {}) }}
       >
         {middleSlots.map((card, i) => renderSlot('middle', Row.Middle, board.middle, card, i, `mid-${i}`))}
-        {middleLabel && <RowOverlay label={middleLabel} cardWidthPx={cardWidthPx} />}
+        {middleEval && <RowOverlay label={middleEval.label} royalty={middleEval.royalty} cardWidthPx={cardWidthPx} />}
       </div>
 
       {/* Bottom row - 5 cards */}
@@ -205,7 +210,7 @@ export function PlayerBoard({
         style={{ gap, ...(fouled ? { transform: 'rotate(3deg)' } : {}) }}
       >
         {bottomSlots.map((card, i) => renderSlot('bottom', Row.Bottom, board.bottom, card, i, `bot-${i}`))}
-        {bottomLabel && <RowOverlay label={bottomLabel} cardWidthPx={cardWidthPx} />}
+        {bottomEval && <RowOverlay label={bottomEval.label} royalty={bottomEval.royalty} cardWidthPx={cardWidthPx} />}
       </div>
 
       {/* Foul overlay */}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,6 +39,19 @@
   animation-duration: var(--timer-ms, 0ms);
 }
 
+/* ---- Royalty row glow ---- */
+/* Gentle gold pulse on a completed row that earns royalty points. */
+@keyframes royalty-glow {
+  0%, 100% { box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.5), 0 0 6px 1px rgba(250, 204, 21, 0.25); }
+  50%      { box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.8), 0 0 14px 3px rgba(250, 204, 21, 0.55); }
+}
+.royalty-glow {
+  /* Static gold ring as the base so the indicator survives reduced-motion
+     (where the pulse animation is collapsed). */
+  box-shadow: inset 0 0 0 1px rgba(250, 204, 21, 0.6);
+  animation: royalty-glow 2.2s ease-in-out infinite;
+}
+
 /* Accessibility: collapse all animations/transitions for users who ask the OS
    for reduced motion. Content stays visible — only the motion is removed.
    The .lp-* overrides pin entrance elements at full opacity (their keyframes


### PR DESCRIPTION
From the BRAINSTORM "Royalties (Visual)" item: a visual indicator on rows that qualify for royalties.

## What

- Completed rows whose hand earns royalty points pulse with a soft gold ring (`royalty-glow` keyframes, 2.2s ease-in-out), and the row's eval label ("Flush +4") renders in gold instead of white.
- The base ring is a **static** box-shadow so the indicator survives reduced-motion, where the pulse animation collapses — the information stays, only the motion goes.
- `rowLabel()` became `rowEval()`, returning `{ label, royalty }` so the overlay knows whether points are attached; no change to label text or foul behavior (fouled boards already suppress labels, hence the glow too).

## Notes on the rest of the brainstorm list

Opponent sorting by standing and the leader crown already exist (`MobileOpponentGrid` sorts by score; rank 1 gets 👑), and the score-reveal count-up with tick/finish sounds already ships in the round/match overlays — this glow was the missing piece.

## Testing

`npm run lint`, `npm run build`, `npm run test:unit` clean locally; label text is unchanged so `scoring.spec.ts` assertions are unaffected. Full E2E in CI.

https://claude.ai/code/session_0163gVKkvdVeyMJPaWYqUDom

---
_Generated by [Claude Code](https://claude.ai/code/session_0163gVKkvdVeyMJPaWYqUDom)_