### PR TITLE
feat(fantasy-land): Fantasy Land for OFC Pineapple

### DIFF
--- a/dealer/package.json
+++ b/dealer/package.json
@@ -8,7 +8,7 @@
     "dev": "tsx --watch src/index.ts",
     "test": "vitest run --config vitest.config.ts",
     "test:unit": "vitest run --config vitest.config.ts src/dealer.test.ts src/bot-strategy.test.ts",
-    "test:integration": "vitest run --config vitest.config.ts src/game-engine-guards.test.ts"
+    "test:integration": "vitest run --config vitest.config.ts src/game-engine-guards.test.ts src/game-engine-fantasy-land.test.ts"
   },
   "engines": {
     "node": "22"

--- a/dealer/src/dealer.ts
+++ b/dealer/src/dealer.ts
@@ -163,9 +163,12 @@ export class Dealer {
         this.scheduleBotPlacements(roomId, game);
       }
 
+      // Fantasy Land players place on their own whole-round clock — they
+      // don't gate street advancement (the engine re-checks authoritatively,
+      // including the street_5 → scoring hold for unfinished FL boards).
       const allPlaced = game.playerOrder.every((uid) => {
         const p = game.players[uid];
-        return !p || p.fouled || p.currentHand.length === 0;
+        return !p || p.fouled || p.fantasyLand || p.currentHand.length === 0;
       });
       if (allPlaced) {
         console.log(`[Dealer] [${roomId}] All placed in ${game.phase} — advancing`);

--- a/dealer/src/game-engine-fantasy-land.test.ts
+++ b/dealer/src/game-engine-fantasy-land.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Integration tests for Fantasy Land engine behavior.
+ * These run against the Firestore emulator.
+ *
+ * REQUIRES: firebase emulators running (firebase emulators:start)
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as admin from 'firebase-admin';
+import type { Firestore } from 'firebase-admin/firestore';
+import type { Card, PlayerState, GameState, Board } from '../../shared/core/types';
+import { GamePhase as GP, Rank, Suit } from '../../shared/core/types';
+import { FL_DEAL_COUNT, INITIAL_DEAL_COUNT, TOTAL_STREETS } from '../../shared/core/constants';
+import { gameDoc } from '../../shared/core/firestore-paths';
+import { emptyBoard } from '../../shared/game-logic/board-utils';
+import { parseGameState } from '../../shared/core/schemas';
+import { maybeStartRound, advanceStreet, scoreRound, resetForNextRound, handlePhaseTimeout } from './game-engine';
+
+// ---- Setup ----
+
+let db: Firestore;
+let testCounter = 0;
+
+beforeAll(() => {
+  process.env.FIRESTORE_EMULATOR_HOST = '127.0.0.1:8080';
+  const app = admin.apps.length
+    ? admin.app()
+    : admin.initializeApp({ projectId: 'pineapple-poker-8f3' });
+  db = app.firestore();
+});
+
+function uniqueRoomId(): string {
+  return `test_fl_${Date.now()}_${testCounter++}`;
+}
+
+// ---- Helpers ----
+
+function card(rank: Rank, suit: Suit = Suit.Spades): Card {
+  return { rank, suit };
+}
+
+function makeHand(n: number): Card[] {
+  const suits = ['s', 'h', 'd', 'c'] as const;
+  return Array.from({ length: n }, (_, i) => ({
+    rank: ((i % 13) + 2) as Card['rank'],
+    suit: suits[i % 4],
+  }));
+}
+
+function makePlayer(uid: string, overrides: Partial<PlayerState> = {}): PlayerState {
+  return {
+    uid,
+    displayName: uid,
+    board: emptyBoard(),
+    currentHand: [],
+    disconnected: false,
+    fouled: false,
+    score: 0,
+    ...overrides,
+  };
+}
+
+/** Complete valid board with QQ on top (Fantasy Land entry). */
+function qqTopBoard(): Board {
+  return {
+    top: [card(Rank.Queen, Suit.Spades), card(Rank.Queen, Suit.Hearts), card(Rank.Two, Suit.Diamonds)],
+    middle: [
+      card(Rank.Nine, Suit.Spades), card(Rank.Nine, Suit.Hearts), card(Rank.Nine, Suit.Diamonds),
+      card(Rank.Four, Suit.Clubs), card(Rank.Four, Suit.Spades),
+    ],
+    bottom: [
+      card(Rank.King, Suit.Spades), card(Rank.King, Suit.Hearts),
+      card(Rank.King, Suit.Diamonds), card(Rank.King, Suit.Clubs),
+      card(Rank.Three, Suit.Spades),
+    ],
+  };
+}
+
+/** Complete valid board, nothing special on top. */
+function plainBoard(): Board {
+  return {
+    top: [card(Rank.Two, Suit.Spades), card(Rank.Five, Suit.Hearts), card(Rank.Seven, Suit.Diamonds)],
+    middle: [
+      card(Rank.Ten, Suit.Spades), card(Rank.Ten, Suit.Hearts),
+      card(Rank.Six, Suit.Diamonds), card(Rank.Seven, Suit.Clubs), card(Rank.Two, Suit.Hearts),
+    ],
+    bottom: [
+      card(Rank.Ace, Suit.Spades), card(Rank.Ace, Suit.Hearts), card(Rank.Ace, Suit.Diamonds),
+      card(Rank.Four, Suit.Clubs), card(Rank.Four, Suit.Spades),
+    ],
+  };
+}
+
+async function setGameState(roomId: string, state: Partial<GameState>) {
+  await db.doc(gameDoc(roomId)).set({
+    gameId: roomId,
+    phase: GP.Lobby,
+    street: 0,
+    round: 1,
+    totalRounds: 3,
+    hostUid: 'p1',
+    playerOrder: [],
+    players: {},
+    settings: { turnTimeoutMs: 30_000, interRoundDelayMs: 5_000 },
+    phaseDeadline: null,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...state,
+  });
+}
+
+async function getGame(roomId: string): Promise<GameState> {
+  const snap = await db.doc(gameDoc(roomId)).get();
+  return parseGameState(snap.data());
+}
+
+// ---- Tests ----
+
+describe('maybeStartRound with a Fantasy Land player', () => {
+  it('deals 14 to the FL player, 5 to others, and sets flDeadline', async () => {
+    const roomId = uniqueRoomId();
+    await setGameState(roomId, {
+      phase: GP.Lobby,
+      round: 2,
+      playerOrder: ['p1', 'p2'],
+      players: {
+        p1: makePlayer('p1', { fantasyLand: true }),
+        p2: makePlayer('p2'),
+      },
+    });
+
+    const started = await maybeStartRound(db, roomId);
+    expect(started).toBe(true);
+
+    const game = await getGame(roomId);
+    expect(game.players['p1'].currentHand).toHaveLength(FL_DEAL_COUNT);
+    expect(game.players['p2'].currentHand).toHaveLength(INITIAL_DEAL_COUNT);
+    expect(game.flDeadline).not.toBeNull();
+    expect(game.flDeadline!).toBeGreaterThan(Date.now() + (TOTAL_STREETS - 1) * 30_000);
+  });
+
+  it('leaves flDeadline null when nobody is in FL', async () => {
+    const roomId = uniqueRoomId();
+    await setGameState(roomId, {
+      phase: GP.Lobby,
+      round: 1,
+      playerOrder: ['p1', 'p2'],
+      players: { p1: makePlayer('p1'), p2: makePlayer('p2') },
+    });
+
+    await maybeStartRound(db, roomId);
+    const game = await getGame(roomId);
+    expect(game.flDeadline ?? null).toBeNull();
+  });
+});
+
+describe('street advancement around a Fantasy Land player', () => {
+  it('advances the street while the FL player still holds 14 cards', async () => {
+    const roomId = uniqueRoomId();
+    await setGameState(roomId, {
+      phase: GP.Lobby,
+      round: 2,
+      playerOrder: ['p1', 'p2'],
+      players: {
+        p1: makePlayer('p1', { fantasyLand: true }),
+        p2: makePlayer('p2'),
+      },
+    });
+    await maybeStartRound(db, roomId);
+
+    // p2 places their 5 (simulate: empty hand); p1 (FL) untouched
+    const game = await getGame(roomId);
+    await db.doc(gameDoc(roomId)).update({
+      players: {
+        ...game.players,
+        p2: { ...game.players['p2'], currentHand: [] },
+      },
+    });
+
+    const result = await advanceStreet(db, roomId);
+    expect(result).toBe('advanced');
+
+    const after = await getGame(roomId);
+    expect(after.street).toBe(2);
+    // FL player keeps their full hand across the street
+    expect(after.players['p1'].currentHand).toHaveLength(FL_DEAL_COUNT);
+    // Non-FL player got the street deal
+    expect(after.players['p2'].currentHand).toHaveLength(3);
+  });
+
+  it('holds street_5 (noop) while the FL board is unfinished', async () => {
+    const roomId = uniqueRoomId();
+    await setGameState(roomId, {
+      phase: GP.Street5,
+      street: 5,
+      playerOrder: ['p1', 'p2'],
+      players: {
+        p1: makePlayer('p1', { fantasyLand: true, currentHand: makeHand(14) }),
+        p2: makePlayer('p2', { board: plainBoard(), currentHand: [] }),
+      },
+      phaseDeadline: Date.now() + 30_000,
+    });
+
+    const result = await advanceStreet(db, roomId);
+    expect(result).toBe('noop');
+    expect((await getGame(roomId)).phase).toBe(GP.Street5);
+  });
+});
+
+describe('Fantasy Land timeout handling', () => {
+  it('does not auto-place the FL player before flDeadline, and re-arms the timer to it', async () => {
+    const roomId = uniqueRoomId();
+    const flDeadline = Date.now() + 60_000;
+    await setGameState(roomId, {
+      phase: GP.Street5,
+      street: 5,
+      playerOrder: ['p1', 'p2'],
+      players: {
+        p1: makePlayer('p1', { fantasyLand: true, currentHand: makeHand(14) }),
+        p2: makePlayer('p2', { board: plainBoard(), currentHand: [] }),
+      },
+      phaseDeadline: Date.now() - 1_000, // street deadline already passed
+      flDeadline,
+    });
+
+    await handlePhaseTimeout(db, roomId);
+
+    const game = await getGame(roomId);
+    expect(game.players['p1'].currentHand).toHaveLength(FL_DEAL_COUNT); // untouched
+    expect(game.phaseDeadline).toBe(flDeadline); // re-armed to the FL deadline
+  });
+
+  it('auto-places the full FL board once flDeadline has passed', async () => {
+    const roomId = uniqueRoomId();
+    await setGameState(roomId, {
+      phase: GP.Street5,
+      street: 5,
+      playerOrder: ['p1', 'p2'],
+      players: {
+        p1: makePlayer('p1', { fantasyLand: true, currentHand: makeHand(14) }),
+        p2: makePlayer('p2', { board: plainBoard(), currentHand: [] }),
+      },
+      phaseDeadline: Date.now() - 1_000,
+      flDeadline: Date.now() - 1_000,
+    });
+
+    await handlePhaseTimeout(db, roomId);
+
+    const game = await getGame(roomId);
+    const b = game.players['p1'].board;
+    expect(game.players['p1'].currentHand).toHaveLength(0);
+    expect(b.top.length + b.middle.length + b.bottom.length).toBe(13);
+    expect(game.phaseDeadline).toBeNull();
+  });
+});
+
+describe('Fantasy Land qualification at scoring', () => {
+  it('QQ-top board earns nextFantasyLand; plain board does not', async () => {
+    const roomId = uniqueRoomId();
+    await setGameState(roomId, {
+      phase: GP.Scoring,
+      street: 5,
+      round: 1,
+      playerOrder: ['p1', 'p2'],
+      players: {
+        p1: makePlayer('p1', { board: qqTopBoard() }),
+        p2: makePlayer('p2', { board: plainBoard() }),
+      },
+    });
+
+    await scoreRound(db, roomId);
+
+    const game = await getGame(roomId);
+    expect(game.players['p1'].nextFantasyLand).toBe(true);
+    expect(game.players['p2'].nextFantasyLand).toBe(false);
+    expect(game.phase).toBe(GP.Complete);
+  });
+
+  it('resetForNextRound promotes nextFantasyLand to fantasyLand', async () => {
+    const roomId = uniqueRoomId();
+    await setGameState(roomId, {
+      phase: GP.Complete,
+      round: 1,
+      playerOrder: ['p1', 'p2'],
+      players: {
+        p1: makePlayer('p1', { nextFantasyLand: true }),
+        p2: makePlayer('p2', { nextFantasyLand: false }),
+      },
+    });
+
+    await resetForNextRound(db, roomId);
+
+    const game = await getGame(roomId);
+    expect(game.players['p1'].fantasyLand).toBe(true);
+    expect(game.players['p1'].nextFantasyLand).toBe(false);
+    expect(game.players['p2'].fantasyLand).toBe(false);
+    expect(game.flDeadline ?? null).toBeNull();
+  });
+});

--- a/dealer/src/game-engine.ts
+++ b/dealer/src/game-engine.ts
@@ -12,22 +12,39 @@ import {
   TOTAL_STREETS,
   TOP_ROW_SIZE,
   FIVE_CARD_ROW_SIZE,
+  FL_DEAL_COUNT,
+  BOARD_CARD_COUNT,
 } from '../../shared/core/constants';
 import { createShuffledDeck, dealCards } from '../../shared/game-logic/deck';
 import { scoreAllPlayers, isFoul } from '../../shared/game-logic/scoring';
+import { qualifiesForFantasyLand, staysInFantasyLand } from '../../shared/game-logic/fantasy-land';
 import { gameDoc, handDoc, deckDoc } from '../../shared/core/firestore-paths';
 import { emptyBoard, phaseForStreet } from '../../shared/game-logic/board-utils';
 import { parseGameState, parseDeckDoc } from '../../shared/core/schemas';
 import { botPlaceInitialDeal, botPlaceStreet } from './bot-strategy';
 
 // ---- Helper: all active (non-fouled) players have placed their cards ----
+// Fantasy Land players set their whole board on their own whole-round clock,
+// so street pacing exempts them; only the street_5 → scoring transition
+// requires their board to be done (callers check flPending for that).
 function allActivePlaced(
   players: Record<string, PlayerState>,
   playerOrder: string[],
 ): boolean {
   return playerOrder.every((uid) => {
     const p = players[uid];
-    return !p || p.fouled || p.currentHand.length === 0;
+    return !p || p.fouled || p.fantasyLand || p.currentHand.length === 0;
+  });
+}
+
+/** A non-fouled Fantasy Land player still has cards to place. */
+function flPending(
+  players: Record<string, PlayerState>,
+  playerOrder: string[],
+): boolean {
+  return playerOrder.some((uid) => {
+    const p = players[uid];
+    return !!p && !p.fouled && !!p.fantasyLand && p.currentHand.length > 0;
   });
 }
 
@@ -67,14 +84,18 @@ export async function maybeStartRound(db: Firestore, roomId: string): Promise<bo
     // Need at least 2 players to start
     if (game.playerOrder.length < 2) return false;
 
-    // Deal cards to all players in playerOrder
+    // Deal cards to all players in playerOrder. Fantasy Land players get
+    // their whole allotment now and place on a whole-round deadline.
     const now = Date.now();
     const phaseDeadline = now + game.settings.turnTimeoutMs;
+    const anyFL = game.playerOrder.some((uid) => game.players[uid]?.fantasyLand);
+    const flDeadline = anyFL ? now + TOTAL_STREETS * game.settings.turnTimeoutMs : null;
     const updatedPlayers: Record<string, PlayerState> = {};
 
     for (const uid of game.playerOrder) {
+      const fl = !!game.players[uid]?.fantasyLand;
       const deck = createShuffledDeck();
-      const { dealt, remaining } = dealCards(deck, INITIAL_DEAL_COUNT);
+      const { dealt, remaining } = dealCards(deck, fl ? FL_DEAL_COUNT : INITIAL_DEAL_COUNT);
 
       updatedPlayers[uid] = {
         ...game.players[uid],
@@ -104,6 +125,7 @@ export async function maybeStartRound(db: Firestore, roomId: string): Promise<bo
       street: 1,
       players: updatedPlayers,
       phaseDeadline,
+      flDeadline,
       updatedAt: now,
     });
 
@@ -137,12 +159,19 @@ export async function advanceStreet(db: Firestore, roomId: string): Promise<'sco
       return 'noop';
     }
 
-    // Verify all active players have placed
+    // Verify all active players have placed (Fantasy Land players exempt —
+    // they place on their own whole-round clock)
     if (!allActivePlaced(game.players, game.playerOrder)) {
       return 'noop';
     }
 
     if (game.street >= TOTAL_STREETS) {
+      // Scoring needs every board complete — hold street_5 while a Fantasy
+      // Land player is still placing. Their flDeadline timeout (or their
+      // submission) will re-trigger advancement.
+      if (flPending(game.players, game.playerOrder)) {
+        return 'noop';
+      }
       // All streets done - go to scoring
       tx.update(gameRef, {
         phase: GP.Scoring,
@@ -152,10 +181,10 @@ export async function advanceStreet(db: Firestore, roomId: string): Promise<'sco
     }
 
     // Read ALL deck docs first (Firestore requires all reads before writes)
-    // Only read decks for non-fouled players
+    // Only read decks for non-fouled, non-FL players (FL already holds all cards)
     const deckSnaps = new Map<string, Card[]>();
     for (const uid of game.playerOrder) {
-      if (game.players[uid].fouled) continue;
+      if (game.players[uid].fouled || game.players[uid].fantasyLand) continue;
       const deckSnap = await tx.get(db.doc(deckDoc(uid, roomId)));
       const deckData = parseDeckDoc(deckSnap.data());
       deckSnaps.set(uid, deckData.cards);
@@ -171,6 +200,11 @@ export async function advanceStreet(db: Firestore, roomId: string): Promise<'sco
       if (game.players[uid].fouled) {
         // Fouled players get no cards
         updatedPlayers[uid] = { ...game.players[uid], currentHand: [] };
+        continue;
+      }
+      if (game.players[uid].fantasyLand) {
+        // FL players keep their existing 14-card hand across streets
+        updatedPlayers[uid] = { ...game.players[uid] };
         continue;
       }
 
@@ -231,15 +265,23 @@ export async function scoreRound(db: Firestore, roomId: string): Promise<void> {
       roundResults[ps.uid] = { netScore: ps.netScore, fouled: ps.fouled };
     }
 
-    // Update game state
+    // Update game state. Fantasy Land for next round: entry is QQ+ on top,
+    // staying (already in FL) is trips top / quads+ bottom — never on a foul.
     const updatedPlayers: Record<string, PlayerState> = {};
     for (const uid of game.playerOrder) {
       const player = game.players[uid];
       const roundScore = roundResults[uid]?.netScore ?? 0;
+      const effFouled = fouls.get(uid) ?? false;
+      const nextFantasyLand = !effFouled && (
+        player.fantasyLand
+          ? staysInFantasyLand(player.board)
+          : qualifiesForFantasyLand(player.board)
+      );
       updatedPlayers[uid] = {
         ...player,
         currentHand: [],
         score: player.score + roundScore,
+        nextFantasyLand,
       };
     }
 
@@ -275,13 +317,16 @@ export async function resetForNextRound(db: Firestore, roomId: string): Promise<
 
     const updatedPlayers: Record<string, PlayerState> = {};
 
-    // Reset active players' boards/hands but keep scores
+    // Reset active players' boards/hands but keep scores. Fantasy Land earned
+    // last round (nextFantasyLand) becomes active for the round about to start.
     for (const uid of game.playerOrder) {
       updatedPlayers[uid] = {
         ...game.players[uid],
         board: emptyBoard(),
         currentHand: [],
         fouled: false,
+        fantasyLand: game.players[uid].nextFantasyLand ?? false,
+        nextFantasyLand: false,
       };
     }
 
@@ -293,6 +338,8 @@ export async function resetForNextRound(db: Firestore, roomId: string): Promise<
           board: emptyBoard(),
           currentHand: [],
           fouled: false,
+          fantasyLand: false,
+          nextFantasyLand: false,
         };
       }
     }
@@ -303,6 +350,7 @@ export async function resetForNextRound(db: Firestore, roomId: string): Promise<
       players: updatedPlayers,
       round: game.round + 1,
       phaseDeadline: null,
+      flDeadline: null,
       roundResults: FieldValue.delete(),
       updatedAt: Date.now(),
     });
@@ -334,6 +382,7 @@ export async function handlePhaseTimeout(db: Firestore, roomId: string): Promise
 
     const updatedPlayers: Record<string, PlayerState> = { ...game.players };
     let changed = false;
+    const flDeadlinePassed = game.flDeadline == null || game.flDeadline <= Date.now();
 
     for (const uid of game.playerOrder) {
       const player = game.players[uid];
@@ -341,6 +390,8 @@ export async function handlePhaseTimeout(db: Firestore, roomId: string): Promise
       // Skip if already placed or already fouled
       if (player.currentHand.length === 0) continue;
       if (player.fouled) continue;
+      // Fantasy Land players run on their own whole-round deadline
+      if (player.fantasyLand && !flDeadlinePassed) continue;
 
       const newBoard: Board = {
         top: [...player.board.top],
@@ -355,7 +406,10 @@ export async function handlePhaseTimeout(db: Firestore, roomId: string): Promise
         [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
       }
 
-      if (game.street === 1) {
+      if (player.fantasyLand) {
+        // FL: fill the whole board; the leftover card is the discard
+        autoPlaceCards(shuffled, newBoard, BOARD_CARD_COUNT);
+      } else if (game.street === 1) {
         // Initial deal: place all 5 cards into free slots
         autoPlaceCards(shuffled, newBoard, 5);
       } else {
@@ -374,11 +428,16 @@ export async function handlePhaseTimeout(db: Firestore, roomId: string): Promise
       console.log(`[Dealer] [${roomId}] Auto-placed cards for ${player.displayName || uid}`);
     }
 
-    if (changed) {
-      // Clear deadline to prevent re-processing
+    // If a Fantasy Land player is still placing (their deadline is later),
+    // re-arm the room timer at flDeadline instead of going idle — otherwise
+    // nothing would wake the room to auto-place them.
+    const flStillPending = !flDeadlinePassed && flPending(updatedPlayers, game.playerOrder);
+    const nextDeadline = flStillPending ? game.flDeadline! : null;
+
+    if (changed || game.phaseDeadline !== nextDeadline) {
       tx.update(gameRef, {
         players: updatedPlayers,
-        phaseDeadline: null,
+        phaseDeadline: nextDeadline,
         updatedAt: Date.now(),
       });
     }
@@ -428,13 +487,6 @@ export async function placeSingleBotCards(db: Firestore, roomId: string, botUid:
     const player = game.players[botUid];
     if (!player?.isBot || player.fouled || player.currentHand.length === 0) return false;
 
-    let decision;
-    if (game.street === 1) {
-      decision = botPlaceInitialDeal(player.currentHand, player.board);
-    } else {
-      decision = botPlaceStreet(player.currentHand, player.board);
-    }
-
     // Apply placements
     const newBoard: Board = {
       top: [...player.board.top],
@@ -442,8 +494,21 @@ export async function placeSingleBotCards(db: Firestore, roomId: string, botUid:
       bottom: [...player.board.bottom],
     };
 
-    for (const p of decision.placements) {
-      newBoard[p.row] = [...newBoard[p.row], p.card];
+    if (player.fantasyLand) {
+      // FL bot: rank-sort descending and fill bottom→middle→top, discarding
+      // the lowest card. Crude (can occasionally foul) but bots are fixtures.
+      const sorted = [...player.currentHand].sort((a, b) => b.rank - a.rank);
+      autoPlaceCards(sorted, newBoard, BOARD_CARD_COUNT);
+    } else {
+      let decision;
+      if (game.street === 1) {
+        decision = botPlaceInitialDeal(player.currentHand, player.board);
+      } else {
+        decision = botPlaceStreet(player.currentHand, player.board);
+      }
+      for (const p of decision.placements) {
+        newBoard[p.row] = [...newBoard[p.row], p.card];
+      }
     }
 
     const updatedPlayers: Record<string, PlayerState> = {

--- a/frontend/src/components/PlayerBoard.tsx
+++ b/frontend/src/components/PlayerBoard.tsx
@@ -71,6 +71,8 @@ interface PlayerBoardProps {
   score?: number;
   disconnected?: boolean;
   rank?: number;
+  /** Player is in Fantasy Land this round. */
+  fantasyLand?: boolean;
   /** Count of trailing cards in each row that are optimistic (placed this turn,
    *  not yet submitted) and therefore takeable-back. */
   pendingByRow?: { top: number; middle: number; bottom: number };
@@ -92,7 +94,7 @@ function RowOverlay({ label, royalty, cardWidthPx }: { label: string; royalty: b
 
 export function PlayerBoard({
   board, playerName, fouled, isCurrentPlayer, onRowClick, hasCardSelected,
-  cardWidthPx, score, disconnected, rank, pendingByRow, onUndoCard,
+  cardWidthPx, score, disconnected, rank, fantasyLand, pendingByRow, onUndoCard,
 }: PlayerBoardProps) {
   const topSlots = padRow(board.top, 3);
   const middleSlots = padRow(board.middle, 5);
@@ -174,6 +176,7 @@ export function PlayerBoard({
         {rank !== undefined && (
           <span className="text-yellow-400 flex-shrink-0">{rank === 1 ? '\u{1F451}' : `#${rank}`}</span>
         )}
+        {fantasyLand && <span className="flex-shrink-0" title="Fantasy Land">🌈</span>}
         {fouled && <span className="text-red-400 flex-shrink-0">[F]</span>}
         {disconnected && <span className="text-red-500 flex-shrink-0">[DC]</span>}
       </div>

--- a/frontend/src/components/mobile/MobileGamePage.tsx
+++ b/frontend/src/components/mobile/MobileGamePage.tsx
@@ -4,7 +4,7 @@ import { useSoundEffects } from '../../audio/useSoundEffects.ts';
 import { useTickSound } from '../../audio/useTickSound.ts';
 import type { Card, Row, Board } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
-import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT, DEFAULT_MATCH_SETTINGS } from '@shared/core/constants';
+import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT, DEFAULT_MATCH_SETTINGS, BOARD_CARD_COUNT, TOTAL_STREETS } from '@shared/core/constants';
 import { isFoul } from '@shared/game-logic/scoring';
 import { placeCards, leaveGame } from '../../api.ts';
 import { trackEvent } from '../../firebase.ts';
@@ -119,9 +119,13 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
   const opponentSize = useContainerSize(opponentRef);
   const playerSize = useContainerSize(playerRef);
 
+  // Fantasy Land: this player sets their whole board (13 of 14 cards) on a
+  // whole-round deadline, independent of the table's street pacing.
+  const isFL = !!gameState.players[uid]?.fantasyLand;
   const countdown = useCountdown(gameState.phaseDeadline);
+  const flCountdown = useCountdown(gameState.flDeadline ?? null);
   const isPlacementPhase = gameState.phase === GamePhase.InitialDeal || STREET_PHASES.has(gameState.phase);
-  useTickSound(countdown, isPlacementPhase && !submitting);
+  useTickSound(isFL ? flCountdown : countdown, isPlacementPhase && !submitting);
   const showTimer = (
     gameState.phase === GamePhase.InitialDeal || STREET_PHASES.has(gameState.phase)
   );
@@ -131,17 +135,24 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
 
   const isInitialDeal = gameState.phase === GamePhase.InitialDeal;
   const isStreet = STREET_PHASES.has(gameState.phase);
-  const requiredPlacements = isInitialDeal ? INITIAL_DEAL_COUNT : STREET_PLACE_COUNT;
+  const requiredPlacements = isFL
+    ? BOARD_CARD_COUNT
+    : isInitialDeal ? INITIAL_DEAL_COUNT : STREET_PLACE_COUNT;
 
   const showRoundOverlay = isRoundComplete && !isMatchComplete;
 
-  // Reset placement state when phase changes
+  // Reset placement state when phase changes — except for a Fantasy Land
+  // player while the table moves between streets: their 14-card hand and
+  // in-progress placements span those transitions.
   const [prevPhase, setPrevPhase] = useState(gameState.phase);
   if (prevPhase !== gameState.phase) {
     setPrevPhase(gameState.phase);
-    setPlacements([]);
-    setSelectedIndex(null);
-    setSubmitting(false);
+    const flSpanningStreets = isFL && STREET_PHASES.has(gameState.phase);
+    if (!flSpanningStreets) {
+      setPlacements([]);
+      setSelectedIndex(null);
+      setSubmitting(false);
+    }
   }
 
   // Track placements by their stable hand index, NOT by card identity, so the
@@ -209,9 +220,10 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
         }));
 
         const placedIdxSet = new Set(newPlacements.map((p) => p.handIndex));
-        // Discard = the one card we didn't place this street, identified by
-        // its hand index so duplicates don't break the lookup.
-        const discardEntry = isStreet
+        // Discard = the one card we didn't place, identified by its hand
+        // index so duplicates don't break the lookup. Streets discard 1 of 3;
+        // Fantasy Land discards 1 of 14.
+        const discardEntry = (isStreet || isFL)
           ? hand
               .map((c, idx) => ({ card: c, idx }))
               .find(({ idx }) => !placedIdxSet.has(idx))
@@ -304,14 +316,22 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
       </div>
 
       {/* Turn timer: depleting bar under the header (replaces a numeric countdown).
-          The ≤10s warning banner below still spells out the seconds. */}
-      {showTimer && gameState.phaseDeadline != null && (
+          The ≤10s warning banner below still spells out the seconds. A Fantasy
+          Land player sees their whole-round deadline instead of street pacing. */}
+      {showTimer && (isFL ? gameState.flDeadline != null : gameState.phaseDeadline != null) && (
         <TimerBar
-          deadline={gameState.phaseDeadline}
-          totalMs={gameState.settings?.turnTimeoutMs ?? DEFAULT_MATCH_SETTINGS.turnTimeoutMs}
-          urgent={countdown <= 10}
-          secondsLeft={countdown}
+          deadline={isFL ? gameState.flDeadline! : gameState.phaseDeadline!}
+          totalMs={(gameState.settings?.turnTimeoutMs ?? DEFAULT_MATCH_SETTINGS.turnTimeoutMs) * (isFL ? TOTAL_STREETS : 1)}
+          urgent={(isFL ? flCountdown : countdown) <= 10}
+          secondsLeft={isFL ? flCountdown : countdown}
         />
+      )}
+
+      {/* Fantasy Land banner */}
+      {isFL && isPlacementPhase && hand.length > 0 && (
+        <div className="bg-purple-900/80 border-b border-purple-700 px-2 py-0.5 text-center text-[10px] text-purple-200 flex-shrink-0">
+          🌈 Fantasy Land — set your whole board: place 13, discard 1
+        </div>
       )}
 
       {/* Observer banner */}
@@ -344,15 +364,16 @@ export function MobileGamePage({ gameState, hand, uid, roomId, onLeaveRoom }: Mo
                 cardWidthPx={playerCardW}
                 score={currentPlayer.score}
                 rank={playerRank}
+                fantasyLand={currentPlayer.fantasyLand}
               />
             )}
           </div>
 
           {/* Low-time warning — placement is easy to lose track of; make the
               impending auto-place unmissable when the player still has cards. */}
-          {showTimer && countdown > 0 && countdown <= 10 && !isObserver && hand.length > 0 && !submitting && (
+          {showTimer && (isFL ? flCountdown : countdown) > 0 && (isFL ? flCountdown : countdown) <= 10 && !isObserver && hand.length > 0 && !submitting && (
             <div className="bg-red-700 text-white text-center text-xs font-bold py-1 animate-pulse flex-shrink-0">
-              ⏰ {countdown}s left — place your cards!
+              ⏰ {isFL ? flCountdown : countdown}s left — place your cards!
             </div>
           )}
 

--- a/frontend/src/components/mobile/MobileHandArea.tsx
+++ b/frontend/src/components/mobile/MobileHandArea.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import type { Card, GameState, Row } from '@shared/core/types';
 import { GamePhase } from '@shared/core/types';
-import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT } from '@shared/core/constants';
+import { INITIAL_DEAL_COUNT, STREET_PLACE_COUNT, BOARD_CARD_COUNT } from '@shared/core/constants';
 import { CardComponent, CARD_ASPECT } from '../CardComponent.tsx';
 import { boardCardCount } from '../../utils/card-utils.ts';
 import type { Placement } from '../../utils/card-utils.ts';
@@ -47,9 +47,11 @@ export function MobileHandArea({
   placements, submitting, cardWidthPx, onDropCard,
 }: MobileHandAreaProps) {
   const isInitialDeal = gameState.phase === GamePhase.InitialDeal;
-  const requiredPlacements = isInitialDeal ? INITIAL_DEAL_COUNT : STREET_PLACE_COUNT;
-
   const player = gameState.players[uid];
+  const isFL = !!player?.fantasyLand;
+  const requiredPlacements = isFL
+    ? BOARD_CARD_COUNT
+    : isInitialDeal ? INITIAL_DEAL_COUNT : STREET_PLACE_COUNT;
   const alreadyPlaced = player ? boardCardCount(player.board) : 0;
   const waitingForOthers = isInitialDeal
     ? alreadyPlaced >= INITIAL_DEAL_COUNT && hand.length === 0
@@ -141,17 +143,22 @@ export function MobileHandArea({
     showCards = true;
   }
 
-  const cardH = Math.round(cardWidthPx * CARD_ASPECT);
-  const cardGap = Math.max(4, Math.round(cardWidthPx * 0.15));
+  // Fantasy Land hands (14 cards) shrink and wrap into two rows of ≤7.
+  const bigHand = availableHand.length > 7;
+  const cardW = bigHand ? Math.max(26, Math.round(cardWidthPx * 0.62)) : cardWidthPx;
+  const cardH = Math.round(cardW * CARD_ASPECT);
+  const cardGap = Math.max(4, Math.round(cardW * 0.15));
+  const handRows = bigHand ? 2 : 1;
+  const handMaxW = bigHand ? 7 * cardW + 6 * cardGap + 1 : undefined;
 
   return (
     <div className="border-t border-gray-700 px-2 py-2 flex-shrink-0">
       <div
         className="flex items-center justify-center"
-        style={{ minHeight: cardH + 8 }}
+        style={{ minHeight: handRows * cardH + (handRows - 1) * cardGap + 8 }}
       >
         {showCards && !allPlaced ? (
-          <div className="flex justify-center" style={{ gap: cardGap }}>
+          <div className="flex justify-center flex-wrap" style={{ gap: cardGap, maxWidth: handMaxW }}>
             {availableHand.map(({ card, handIndex }, i) => (
               <div
                 key={handIndex}
@@ -165,7 +172,7 @@ export function MobileHandArea({
               >
                 <CardComponent
                   card={card}
-                  widthPx={cardWidthPx}
+                  widthPx={cardW}
                   selected={selectedIndex === i}
                   onClick={() => handleCardClick(i)}
                 />
@@ -184,11 +191,11 @@ export function MobileHandArea({
         <div
           className="fixed z-[200] pointer-events-none opacity-90 drop-shadow-xl"
           style={{
-            left: drag.x - cardWidthPx / 2,
+            left: drag.x - cardW / 2,
             top: drag.y - cardH * 0.75,
           }}
         >
-          <CardComponent card={availableHand[drag.index].card} widthPx={cardWidthPx} />
+          <CardComponent card={availableHand[drag.index].card} widthPx={cardW} />
         </div>
       )}
 

--- a/frontend/src/components/mobile/MobileOpponentGrid.tsx
+++ b/frontend/src/components/mobile/MobileOpponentGrid.tsx
@@ -59,6 +59,7 @@ export function MobileOpponentGrid({ gameState, currentUid, cardWidthPx, cols }:
                 score={player.score}
                 disconnected={player.disconnected}
                 rank={rankByUid.get(uid)}
+                fantasyLand={player.fantasyLand}
               />
             );
           })}

--- a/functions/src/player-actions.ts
+++ b/functions/src/player-actions.ts
@@ -12,6 +12,7 @@ import {
   ROUNDS_PER_MATCH,
   MAX_PLAYERS,
   DEFAULT_MATCH_SETTINGS,
+  BOARD_CARD_COUNT,
 } from '../../shared/core/constants';
 import { gameDoc, handDoc, deckDoc } from '../../shared/core/firestore-paths';
 import { emptyBoard } from '../../shared/game-logic/board-utils';
@@ -263,8 +264,20 @@ export const placeCards = onCall({ maxInstances: 10 }, async (request) => {
       );
     }
 
-    // Validate placement count
-    if (game.street === 1) {
+    // Validate placement count. Fantasy Land players set the whole board in
+    // one submission (13 placed + 1 discarded from their 14-card hand),
+    // regardless of which street the rest of the table is on.
+    if (player.fantasyLand) {
+      if (placements.length !== BOARD_CARD_COUNT) {
+        throw new HttpsError(
+          'invalid-argument',
+          `Fantasy Land: must place exactly ${BOARD_CARD_COUNT} cards.`,
+        );
+      }
+      if (!discard) {
+        throw new HttpsError('invalid-argument', 'Must discard 1 card.');
+      }
+    } else if (game.street === 1) {
       if (placements.length !== INITIAL_DEAL_COUNT) {
         throw new HttpsError(
           'invalid-argument',
@@ -440,6 +453,9 @@ export const playAgain = onCall({ maxInstances: 10 }, async (request) => {
         currentHand: [],
         fouled: false,
         score: 0,
+        // Fantasy Land does not carry across matches
+        fantasyLand: false,
+        nextFantasyLand: false,
       };
       updatedPlayerOrder.push(pUid);
     }
@@ -452,6 +468,7 @@ export const playAgain = onCall({ maxInstances: 10 }, async (request) => {
       playerOrder: updatedPlayerOrder,
       roundResults: FieldValue.delete(),
       phaseDeadline: null,
+      flDeadline: FieldValue.delete(),
       // Clear all run-mode state — host must opt back in via Start
       runMode: FieldValue.delete(),
       totalRounds: ROUNDS_PER_MATCH,

--- a/shared/core/constants.ts
+++ b/shared/core/constants.ts
@@ -62,6 +62,12 @@ export const SCOOP_BONUS = 3;
 /** Number of cards dealt on the initial street. */
 export const INITIAL_DEAL_COUNT = 5;
 
+/** Cards dealt all at once to a Fantasy Land player (place 13, discard 1). */
+export const FL_DEAL_COUNT = 14;
+
+/** Total cards on a complete board (3 + 5 + 5). */
+export const BOARD_CARD_COUNT = 13;
+
 /** Number of cards dealt on streets 2-5. */
 export const STREET_DEAL_COUNT = 3;
 

--- a/shared/core/schemas.ts
+++ b/shared/core/schemas.ts
@@ -64,6 +64,8 @@ export const PlayerStateSchema = z.object({
   fouled: z.boolean(),
   score: z.number(),
   isBot: z.boolean().optional(),
+  fantasyLand: z.boolean().optional(),
+  nextFantasyLand: z.boolean().optional(),
 });
 
 // ---- Round results ----
@@ -96,6 +98,7 @@ export const GameStateSchema = z.object({
   createdAt: z.number(),
   updatedAt: z.number(),
   phaseDeadline: z.number().nullable(),
+  flDeadline: z.number().nullable().optional(),
   // Run mode (optional — present only for roguelike runs)
   runMode: z.boolean().optional(),
   charms: z.record(z.string(), z.array(z.string())).optional(),

--- a/shared/core/types.ts
+++ b/shared/core/types.ts
@@ -104,6 +104,12 @@ export interface PlayerState {
   fouled: boolean;
   score: number;
   isBot?: boolean;
+  /** In Fantasy Land this round: dealt all 14 cards at once, sets the whole
+   *  board in one submission, exempt from street pacing. */
+  fantasyLand?: boolean;
+  /** Earned Fantasy Land for the next round of this match (set at scoring,
+   *  consumed by resetForNextRound). */
+  nextFantasyLand?: boolean;
 }
 
 /** Subcollection document: games/{roomId}/hands/{uid} */
@@ -153,6 +159,9 @@ export interface GameState {
   createdAt: number;
   updatedAt: number;
   phaseDeadline: number | null;  // Unix timestamp when phase expires
+  /** Whole-round deadline for Fantasy Land players (roundStart + 5 × turnTimeoutMs).
+   *  Null/absent when nobody is in Fantasy Land this round. */
+  flDeadline?: number | null;
   // ---- Legacy run-mode fields (feature removed) ----
   // Kept as optional so old Firestore docs written while "Pineapple Run" was
   // live still parse. Nothing writes these anymore; playAgain scrubs them.

--- a/shared/game-logic/fantasy-land.test.ts
+++ b/shared/game-logic/fantasy-land.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { qualifiesForFantasyLand, staysInFantasyLand } from './fantasy-land';
+import { Rank, Suit } from '../core/types';
+import type { Board, Card } from '../core/types';
+
+// -- Helpers --
+
+function card(rank: Rank, suit: Suit = Suit.Spades): Card {
+  return { rank, suit };
+}
+
+/** Valid board with a configurable top pair; mid/bottom strong enough to never foul. */
+function boardWithTopPair(pairRank: Rank): Board {
+  return {
+    top: [card(pairRank, Suit.Spades), card(pairRank, Suit.Hearts), card(Rank.Two, Suit.Diamonds)],
+    middle: [
+      // Full house — beats any top pair
+      card(Rank.Nine, Suit.Spades), card(Rank.Nine, Suit.Hearts), card(Rank.Nine, Suit.Diamonds),
+      card(Rank.Four, Suit.Clubs), card(Rank.Four, Suit.Spades),
+    ],
+    bottom: [
+      // Quads — beats the full house
+      card(Rank.King, Suit.Spades), card(Rank.King, Suit.Hearts),
+      card(Rank.King, Suit.Diamonds), card(Rank.King, Suit.Clubs),
+      card(Rank.Three, Suit.Spades),
+    ],
+  };
+}
+
+/** Valid board with trips on top (and stronger mid/bottom). */
+function boardWithTopTrips(): Board {
+  return {
+    top: [card(Rank.Five, Suit.Spades), card(Rank.Five, Suit.Hearts), card(Rank.Five, Suit.Diamonds)],
+    middle: [
+      card(Rank.Nine, Suit.Spades), card(Rank.Nine, Suit.Hearts), card(Rank.Nine, Suit.Diamonds),
+      card(Rank.Four, Suit.Clubs), card(Rank.Four, Suit.Spades),
+    ],
+    bottom: [
+      card(Rank.King, Suit.Spades), card(Rank.King, Suit.Hearts),
+      card(Rank.King, Suit.Diamonds), card(Rank.King, Suit.Clubs),
+      card(Rank.Three, Suit.Spades),
+    ],
+  };
+}
+
+/** Plain valid board: no top pair, full house bottom. */
+function plainBoard(): Board {
+  return {
+    top: [card(Rank.Two, Suit.Spades), card(Rank.Five, Suit.Hearts), card(Rank.Seven, Suit.Diamonds)],
+    middle: [
+      card(Rank.Ten, Suit.Spades), card(Rank.Ten, Suit.Hearts),
+      card(Rank.Six, Suit.Diamonds), card(Rank.Seven, Suit.Clubs), card(Rank.Two, Suit.Hearts),
+    ],
+    bottom: [
+      card(Rank.Ace, Suit.Spades), card(Rank.Ace, Suit.Hearts), card(Rank.Ace, Suit.Diamonds),
+      card(Rank.Four, Suit.Clubs), card(Rank.Four, Suit.Spades),
+    ],
+  };
+}
+
+describe('qualifiesForFantasyLand', () => {
+  it('QQ on top qualifies', () => {
+    expect(qualifiesForFantasyLand(boardWithTopPair(Rank.Queen))).toBe(true);
+  });
+
+  it('KK and AA on top qualify', () => {
+    expect(qualifiesForFantasyLand(boardWithTopPair(Rank.King))).toBe(true);
+    expect(qualifiesForFantasyLand(boardWithTopPair(Rank.Ace))).toBe(true);
+  });
+
+  it('JJ on top does NOT qualify (boundary)', () => {
+    expect(qualifiesForFantasyLand(boardWithTopPair(Rank.Jack))).toBe(false);
+  });
+
+  it('trips on top qualifies', () => {
+    expect(qualifiesForFantasyLand(boardWithTopTrips())).toBe(true);
+  });
+
+  it('no pair on top does not qualify', () => {
+    expect(qualifiesForFantasyLand(plainBoard())).toBe(false);
+  });
+
+  it('fouled board never qualifies, even with AA on top', () => {
+    const board = boardWithTopPair(Rank.Ace);
+    // Weaken the middle below the top pair → foul
+    board.middle = [
+      card(Rank.Three, Suit.Spades), card(Rank.Four, Suit.Hearts),
+      card(Rank.Six, Suit.Diamonds), card(Rank.Seven, Suit.Clubs), card(Rank.Nine, Suit.Clubs),
+    ];
+    expect(qualifiesForFantasyLand(board)).toBe(false);
+  });
+
+  it('incomplete board does not qualify', () => {
+    const board = boardWithTopPair(Rank.Queen);
+    board.bottom = board.bottom.slice(0, 4);
+    expect(qualifiesForFantasyLand(board)).toBe(false);
+  });
+});
+
+describe('staysInFantasyLand', () => {
+  it('trips on top stays', () => {
+    expect(staysInFantasyLand(boardWithTopTrips())).toBe(true);
+  });
+
+  it('quads on bottom stays', () => {
+    expect(staysInFantasyLand(boardWithTopPair(Rank.Two))).toBe(true); // bottom is quads
+  });
+
+  it('straight flush on bottom stays', () => {
+    const board = plainBoard();
+    board.bottom = [
+      card(Rank.Five, Suit.Hearts), card(Rank.Six, Suit.Hearts), card(Rank.Seven, Suit.Hearts),
+      card(Rank.Eight, Suit.Hearts), card(Rank.Nine, Suit.Hearts),
+    ];
+    expect(staysInFantasyLand(board)).toBe(true);
+  });
+
+  it('QQ on top does NOT stay (entry bar ≠ stay bar)', () => {
+    const board = boardWithTopPair(Rank.Queen);
+    // Replace quads bottom with a full house so only the top pair matters
+    board.bottom = [
+      card(Rank.Ace, Suit.Spades), card(Rank.Ace, Suit.Hearts), card(Rank.Ace, Suit.Diamonds),
+      card(Rank.Three, Suit.Clubs), card(Rank.Three, Suit.Hearts),
+    ];
+    expect(staysInFantasyLand(board)).toBe(false);
+  });
+
+  it('full house on bottom does not stay', () => {
+    expect(staysInFantasyLand(plainBoard())).toBe(false);
+  });
+});

--- a/shared/game-logic/fantasy-land.ts
+++ b/shared/game-logic/fantasy-land.ts
@@ -1,0 +1,35 @@
+import type { Board } from '../core/types';
+import { HandRank, Rank, ThreeCardHandRank } from '../core/types';
+import { evaluate3CardHand, evaluate5CardHand } from './hand-evaluation';
+import { isFoul } from './scoring';
+import { BOARD_CARD_COUNT } from '../core/constants';
+
+function boardComplete(board: Board): boolean {
+  return board.top.length + board.middle.length + board.bottom.length === BOARD_CARD_COUNT;
+}
+
+/**
+ * Entry: QQ or better on the top row (pair of queens+ or any trips) on a
+ * complete, non-fouled board earns Fantasy Land for the next round.
+ */
+export function qualifiesForFantasyLand(board: Board): boolean {
+  if (!boardComplete(board) || isFoul(board)) return false;
+  const top = evaluate3CardHand(board.top);
+  if (top.handRank === ThreeCardHandRank.ThreeOfAKind) return true;
+  if (top.handRank === ThreeCardHandRank.Pair) {
+    return top.kickers[0] >= Rank.Queen;
+  }
+  return false;
+}
+
+/**
+ * Staying in: while in Fantasy Land, trips on top or quads-or-better on the
+ * bottom (complete, non-fouled board) keeps you there next round.
+ */
+export function staysInFantasyLand(board: Board): boolean {
+  if (!boardComplete(board) || isFoul(board)) return false;
+  const top = evaluate3CardHand(board.top);
+  if (top.handRank === ThreeCardHandRank.ThreeOfAKind) return true;
+  const bottom = evaluate5CardHand(board.bottom);
+  return bottom.handRank >= HandRank.FourOfAKind;
+}


### PR DESCRIPTION
Closes #95.

Fantasy Land for OFC Pineapple, per the design settled on the issue: **visible-board v1, whole-round deadline, flat 14 cards.**

## Rules implemented

- **Qualify**: QQ+ on top (pair of queens or better, or trips) on a complete, non-fouled board → Fantasy Land next round (same match).
- **In FL**: dealt all 14 cards on the initial deal; set the whole board in one submission (place 13, discard 1) on a **whole-round deadline** (`flDeadline = roundStart + 5 × turnTimeoutMs`).
- **Stay**: trips on top or quads+ on bottom while in FL.
- FL doesn't carry across `playAgain` (scrubbed there).

## How it works in the simultaneous model

The FL player never blocks anyone: streets advance around them (they're exempt from the all-placed check and receive no street deals), and only the street_5 → scoring transition waits for their board. Phase timeouts skip FL players until `flDeadline`; when a street deadline fires with an FL player still placing, the room timer **re-arms to `flDeadline`** instead of going idle — the room can't strand. After `flDeadline`, the existing auto-placer fills their remaining slots. FL bots rank-sort and fill bottom→top.

## Touchpoints

- `shared`: `fantasyLand`/`nextFantasyLand` on PlayerState, `flDeadline` on GameState (all optional — old docs parse), `FL_DEAL_COUNT`/`BOARD_CARD_COUNT`, new `fantasy-land.ts` with `qualifiesForFantasyLand`/`staysInFantasyLand`.
- `dealer`: deal/pacing/hold/timeout/qualification/promotion logic in `game-engine.ts`; FL-exempt all-placed trigger in `dealer.ts`.
- `functions`: `placeCards` accepts the FL shape (13 + discard, any placement phase); `playAgain` scrubs FL state.
- `frontend`: two-row 14-card hand, FL banner, timer bar + warning banner on the whole-round clock, 🌈 board badge, placement state survives street transitions for the FL player.

## Testing

- **13 unit tests** (`fantasy-land.test.ts`): QQ/JJ boundary, trips, fouls, incomplete boards, entry-vs-stay bars.
- **8 integration tests** (`game-engine-fantasy-land.test.ts`) — **run and passing against the Firestore emulator** (launched via the cached emulator jar): 14-card deal + `flDeadline`, street advancement around FL, street_5 hold, pre-deadline timeout no-op + timer re-arm, post-deadline auto-place, scoring qualification, round-reset promotion. Registered in `test:dealer:integration`.
- Full lint/build across all three workspaces + 134 unit tests green. CI e2e verifies the non-FL path is regression-free (FL can't trigger in e2e — decks are random).

The FL trigger itself can't be E2E'd with random decks; manual verification path: play a round to QQ-top (or temporarily seed `nextFantasyLand` via emulator) and watch the next round.

https://claude.ai/code/session_0163gVKkvdVeyMJPaWYqUDom

---
_Generated by [Claude Code](https://claude.ai/code/session_0163gVKkvdVeyMJPaWYqUDom)_