### PR TITLE
Add single-player Saloon mode: traditional OFC campaign (The Frontier Trail)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ npm install                       # One command installs all workspace deps
 ### Unit tests (no emulators needed)
 
 ```bash
-npm run test:unit                  # Shared logic + dealer unit tests
+npm run test:unit                  # Shared logic + frontend + dealer unit tests
 npm run test:dealer:unit           # Dealer unit tests only (dealer/src/dealer.test.ts)
 ```
 
@@ -45,6 +45,8 @@ Dealer unit tests (`dealer/src/dealer.test.ts`) use mocked Firestore and vitest 
 - Timeout callbacks: correct sequencing (e.g. handlePhaseTimeout before checkAndAdvance)
 
 Shared logic tests (`shared/`) use vitest to verify scoring, hand evaluation, and board utils.
+
+Frontend unit tests (`frontend/vitest.config.ts`, run from repo root) cover the single-player Saloon engine (`frontend/src/saloon/engine.test.ts` — shared-deck dealing, turn order, street advancement, scoring, match flow, bot-play legality) plus audio intensity.
 
 ### Integration tests (requires Firestore emulator)
 
@@ -73,7 +75,7 @@ npm test                           # Playwright E2E tests
 
 E2E tests are in `e2e/`. Each test generates a unique room code for isolation — no shared state between tests.
 
-`e2e/` has 11 specs. The default `npm test` suite runs 9 (`bot` + `stress` are always ignored via `playwright.config.ts`; production runs additionally ignore `scoring` + `sit-out`):
+`e2e/` has 12 specs. The default `npm test` suite runs 10 (`bot` + `stress` are always ignored via `playwright.config.ts`; production runs additionally ignore `scoring` + `sit-out`):
 - `00-warmup.spec.ts` — absorbs the worker browser's one-time cold-start cost
 - `happy-path.spec.ts` — 2-player full 3-round match, play again
 - `card-placement.spec.ts` — card placement UI, auto-submit, auto-discard
@@ -83,6 +85,7 @@ E2E tests are in `e2e/`. Each test generates a unique room code for isolation �
 - `resume-game.spec.ts` — player who lost the room URL rejoins via home-screen banner
 - `observer.spec.ts` — late joiner observes full match, promoted via play-again, 3-player game
 - `scoring.spec.ts` — foul penalty scores (+6/-6), pairwise breakdown, cumulative totals
+- `saloon.spec.ts` — single-player Saloon mode: campaign map gating, turn-based hand vs bot (client-only, no emulator state)
 - `bot.spec.ts`, `stress.spec.ts` — always ignored by config (manual / load testing)
 
 
@@ -188,6 +191,12 @@ Host sets settings in Lobby UI before starting. In dev mode, `?timeout=5000` URL
 Classic OFC Pineapple only: a 3-round match (`ROUNDS_PER_MATCH`). Unlike table OFC (max 3 players, turn-based, shared deck), this game deals each player their **own** shuffled 52-card deck and everyone places **simultaneously** against a shared street timer — which is what lets a room hold up to `MAX_PLAYERS` players with no waiting. Scoring is pairwise across all active players.
 
 A roguelike "Pineapple Run" mode existed and was removed (#64). `GameState` keeps its fields (`runMode`, `charms`, `mutations`, etc. in `shared/core/types.ts`) and `GamePhase.CharmPick` as **vestigial optional schema fields** so old prod Firestore docs still parse; `playAgain` scrubs them. Nothing writes them anymore.
+
+### Single-player Saloon mode ("The Frontier Trail")
+
+A separate, fully client-side single-player campaign at `/?saloon=1` (linked from the home screen). This one IS **traditional table OFC**: one shared 52-card deck, turn-based placement clockwise from the button, max 3 seats (3 × 17 = 51 cards). Old-West theme: a ladder of 5 locales (`frontend/src/saloon/campaign.ts`) with named bot characters in 3 skill tiers (greenhorn/gunslinger/outlaw — implemented as score jitter on the bot strategy), rising stakes ($/point), and a localStorage bankroll/unlock progression (`saloon_progress_v1`).
+
+Everything lives in `frontend/src/saloon/` and touches **no Firebase**: game logic is **vendored** (copied, not imported) from `shared/` and `dealer/src/bot-strategy.ts` into `frontend/src/saloon/vendor/` so the mode stays decoupled from the multiplayer stack. The turn-based engine is `frontend/src/saloon/engine.ts` (pure state-transition functions, unit-tested). If you fix a bug in shared scoring/hand-eval, check whether the vendored copy needs the same fix.
 
 ### Timeout = Auto-Place
 

--- a/e2e/saloon.spec.ts
+++ b/e2e/saloon.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Single-player Saloon mode (The Frontier Trail).
+ *
+ * Fully client-side — no rooms, dealer, or emulator state involved. Covers:
+ * entry from the home screen, the campaign map (locks + bankroll), and
+ * playing the first two streets of a hand against a bot (turn passing,
+ * auto-submit, auto-discard).
+ */
+
+/** Place `count` cards: tap the first card in hand, tap the given row. */
+async function placeCards(page: Page, rows: string[]) {
+  const board = page.getByTestId('saloon-my-board');
+  for (const row of rows) {
+    await page.getByTestId('saloon-hand-card-0').click();
+    await board.getByTestId(`saloon-row-${row}`).click();
+  }
+}
+
+test('frontier trail: map gating, turn-based hand vs bot, walk away', async ({ page }) => {
+  // Entry from the multiplayer home screen
+  await page.goto('/');
+  await page.getByTestId('saloon-link').click();
+
+  // Campaign map: fresh progress shows $100 bankroll, only stop 1 unlocked
+  await expect(page.getByTestId('saloon-bankroll')).toHaveText('$100');
+  await expect(page.getByTestId('saloon-play-1')).toBeVisible();
+  await expect(page.getByTestId('saloon-play-2')).not.toBeVisible();
+  await expect(page.getByText('Tumbleweed Ted')).toBeVisible();
+
+  // Sit down at Dusty Gulch — hero acts first on hand 1
+  await page.getByTestId('saloon-play-1').click();
+  await expect(page.getByTestId('saloon-turn-banner')).toContainText('Your deal', { timeout: 10_000 });
+  await expect(page.getByTestId('saloon-hand-card-4')).toBeVisible();
+
+  // Street 1: place all 5 (auto-submits on the 5th) → bot's turn
+  await placeCards(page, ['bottom', 'bottom', 'bottom', 'middle', 'middle']);
+  await expect(page.getByTestId('saloon-turn-banner')).toContainText('Tumbleweed Ted', { timeout: 5_000 });
+
+  // Bot plays, street 2 comes back to us with 3 dealt cards
+  await expect(page.getByTestId('saloon-turn-banner')).toContainText('Your turn', { timeout: 15_000 });
+  await expect(page.getByTestId('saloon-hand-card-2')).toBeVisible();
+
+  // Street 2: place 2, third card is auto-discarded → bot's turn again
+  await placeCards(page, ['bottom', 'middle']);
+  await expect(page.getByTestId('saloon-turn-banner')).toContainText('Tumbleweed Ted', { timeout: 5_000 });
+  await expect(page.getByTestId('saloon-hand-card-0')).not.toBeVisible();
+
+  // Walk away mid-match (confirm dialog) → back on the trail, bankroll untouched
+  page.on('dialog', (dialog) => dialog.accept());
+  await page.getByRole('button', { name: 'Walk away' }).click();
+  await expect(page.getByTestId('saloon-bankroll')).toHaveText('$100', { timeout: 5_000 });
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { useResumableGame, LAST_ROOM_KEY } from './hooks/useResumableGame.ts';
 import { RoomSelector } from './components/RoomSelector.tsx';
 import { Lobby } from './components/Lobby.tsx';
 import { MobileGamePage } from './components/mobile/MobileGamePage.tsx';
+import { SaloonApp } from './saloon/SaloonApp.tsx';
 import { GamePhase } from '@shared/core/types';
 
 class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
@@ -46,6 +47,20 @@ function getRoomFromUrl(): string | null {
   return params.get('room') || null;
 }
 
+function getSaloonFromUrl(): boolean {
+  return new URLSearchParams(window.location.search).has('saloon');
+}
+
+function setSaloonInUrl(on: boolean) {
+  const url = new URL(window.location.href);
+  if (on) {
+    url.searchParams.set('saloon', '1');
+  } else {
+    url.searchParams.delete('saloon');
+  }
+  history.replaceState(null, '', url.toString());
+}
+
 function setRoomInUrl(roomId: string | null) {
   const url = new URL(window.location.href);
   if (roomId) {
@@ -59,12 +74,16 @@ function setRoomInUrl(roomId: string | null) {
 function App() {
   const { user, loading: authLoading, displayName, setDisplayName, signIn } = useAuth();
   const [roomId, setRoomId] = useState<string | null>(getRoomFromUrl);
+  const [saloonMode, setSaloonMode] = useState<boolean>(getSaloonFromUrl);
   const { gameState, loading: gameLoading } = useGameState(roomId);
   const hand = usePlayerHand(user?.uid, roomId);
   const { resumable, dismiss: dismissResumable } = useResumableGame(user?.uid, !roomId);
   // Sync URL on popstate (back/forward)
   useEffect(() => {
-    const onPopState = () => setRoomId(getRoomFromUrl());
+    const onPopState = () => {
+      setRoomId(getRoomFromUrl());
+      setSaloonMode(getSaloonFromUrl());
+    };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
@@ -88,6 +107,18 @@ function App() {
     setRoomId(null);
     setRoomInUrl(null);
   };
+
+  // Single-player saloon mode — fully client-side, no auth or room needed.
+  if (saloonMode) {
+    return (
+      <SaloonApp
+        onExit={() => {
+          setSaloonInUrl(false);
+          setSaloonMode(false);
+        }}
+      />
+    );
+  }
 
   if (authLoading) {
     return (

--- a/frontend/src/components/RoomSelector.tsx
+++ b/frontend/src/components/RoomSelector.tsx
@@ -193,6 +193,16 @@ export function RoomSelector({ displayName, setDisplayName, signIn, onRoomJoined
           </div>
         </div>
 
+        {/* ---- Single player ---- */}
+        <a
+          href="?saloon=1"
+          data-testid="saloon-link"
+          className="lp-fade-up mt-3 w-full py-2.5 rounded-lg border border-amber-700/60 bg-amber-950/40 hover:bg-amber-900/50 text-amber-300 text-sm font-bold transition-colors flex items-center justify-center gap-2"
+          style={{ animationDelay: '360ms' }}
+        >
+          🤠 Single player — The Frontier Trail
+        </a>
+
         {/* ---- Footer ---- */}
         <div
           className="lp-fade-up text-center mt-5"

--- a/frontend/src/saloon/CampaignMap.tsx
+++ b/frontend/src/saloon/CampaignMap.tsx
@@ -1,0 +1,115 @@
+/**
+ * The Frontier Trail — campaign level select. Wanted-poster cards for each
+ * stop on the trail; beat a table to unlock the next one.
+ */
+import { LEVELS, SKILL_LABELS, type SaloonLevel, type SaloonProgress } from './campaign.ts';
+
+interface CampaignMapProps {
+  progress: SaloonProgress;
+  onPlay: (level: SaloonLevel) => void;
+  onReset: () => void;
+  onExit: () => void;
+}
+
+export function CampaignMap({ progress, onPlay, onReset, onExit }: CampaignMapProps) {
+  const handleReset = () => {
+    if (window.confirm('Burn your trail progress and start over with a fresh bankroll?')) {
+      onReset();
+    }
+  };
+
+  return (
+    <div className="min-h-[100dvh] bg-stone-950 flex justify-center">
+      <div className="w-full max-w-[430px] bg-gradient-to-b from-stone-900 via-amber-950/40 to-stone-900 text-amber-100 flex flex-col">
+        {/* Header */}
+        <div className="text-center px-4 pt-6 pb-4">
+          <div className="text-3xl mb-1">🤠</div>
+          <h1 className="font-serif text-2xl font-black tracking-wide text-amber-200">
+            THE FRONTIER TRAIL
+          </h1>
+          <p className="text-amber-400/80 text-xs mt-1">
+            Single player · classic table OFC Pineapple · one deck, no mercy
+          </p>
+          <div className="inline-flex items-center gap-2 mt-3 px-4 py-1.5 rounded-full border border-amber-700/60 bg-black/40">
+            <span className="text-amber-400/80 text-xs">Bankroll</span>
+            <span
+              className={`font-bold text-sm ${progress.bankroll >= 0 ? 'text-green-400' : 'text-red-400'}`}
+              data-testid="saloon-bankroll"
+            >
+              ${progress.bankroll}
+            </span>
+          </div>
+        </div>
+
+        {/* Trail */}
+        <div className="flex-1 px-4 pb-4 space-y-3">
+          {LEVELS.map((level) => {
+            const unlocked = level.id <= progress.unlocked;
+            const wins = progress.wins[level.id] ?? 0;
+            return (
+              <div
+                key={level.id}
+                className={`rounded-lg border-2 p-3 ${
+                  unlocked
+                    ? 'border-amber-700 bg-amber-950/30'
+                    : 'border-stone-800 bg-black/30 opacity-60'
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <div className="font-serif font-bold text-amber-200 text-sm">
+                      {unlocked ? '' : '🔒 '}
+                      Stop {level.id} — {level.location}
+                      {wins > 0 && <span className="text-yellow-400 ml-1">{'⭐'.repeat(Math.min(wins, 3))}</span>}
+                    </div>
+                    <div className="text-[11px] text-amber-400/80 italic mt-0.5">{level.tagline}</div>
+                  </div>
+                  <div className="text-right flex-shrink-0 text-[10px] text-amber-300/90 leading-4">
+                    <div>${level.stake}/pt</div>
+                    <div>{level.hands} hands</div>
+                    <div>{level.opponents.length + 1} seats</div>
+                  </div>
+                </div>
+
+                <div className="mt-2 space-y-1">
+                  {level.opponents.map((o) => (
+                    <div key={o.id} className="flex items-baseline gap-1.5 text-[11px]">
+                      <span>{o.avatar}</span>
+                      <span className="font-bold text-amber-100">{o.name}</span>
+                      <span className="text-amber-500/80">· {SKILL_LABELS[o.skill]}</span>
+                    </div>
+                  ))}
+                  {unlocked && (
+                    <div className="text-[10px] text-amber-400/60 italic">
+                      {level.opponents.map((o) => o.blurb).join(' ')}
+                    </div>
+                  )}
+                </div>
+
+                {unlocked && (
+                  <button
+                    onClick={() => onPlay(level)}
+                    data-testid={`saloon-play-${level.id}`}
+                    className="mt-2.5 w-full py-2 rounded bg-amber-700 hover:bg-amber-600 active:bg-amber-800 text-white text-xs font-bold"
+                  >
+                    {wins > 0 ? 'Sit back down' : 'Take a seat'}
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        <div className="px-4 pb-6 flex items-center justify-between text-[11px]">
+          <button onClick={onExit} className="text-amber-500/80 hover:text-amber-300 underline underline-offset-2">
+            ← Back to multiplayer
+          </button>
+          <button onClick={handleReset} className="text-red-400/70 hover:text-red-300 underline underline-offset-2">
+            Reset progress
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/saloon/SaloonApp.tsx
+++ b/frontend/src/saloon/SaloonApp.tsx
@@ -1,0 +1,47 @@
+/**
+ * Top-level shell for the single-player Saloon mode (The Frontier Trail).
+ * Entirely client-side: no Firebase, no auth — progress lives in
+ * localStorage. Reached via the `?saloon` URL param (see App.tsx).
+ */
+import { useState } from 'react';
+import {
+  loadProgress,
+  resetProgress,
+  settleMatch,
+  type SaloonLevel,
+  type SaloonProgress,
+} from './campaign.ts';
+import { CampaignMap } from './CampaignMap.tsx';
+import { SaloonTable } from './SaloonTable.tsx';
+
+interface SaloonAppProps {
+  onExit: () => void;
+}
+
+export function SaloonApp({ onExit }: SaloonAppProps) {
+  const [progress, setProgress] = useState<SaloonProgress>(loadProgress);
+  const [activeLevel, setActiveLevel] = useState<SaloonLevel | null>(null);
+
+  if (activeLevel) {
+    return (
+      <SaloonTable
+        key={activeLevel.id}
+        level={activeLevel}
+        onMatchEnd={(heroPoints, won) => {
+          setProgress(settleMatch(progress, activeLevel, heroPoints, won));
+          setActiveLevel(null);
+        }}
+        onQuit={() => setActiveLevel(null)}
+      />
+    );
+  }
+
+  return (
+    <CampaignMap
+      progress={progress}
+      onPlay={setActiveLevel}
+      onReset={() => setProgress(resetProgress())}
+      onExit={onExit}
+    />
+  );
+}

--- a/frontend/src/saloon/SaloonBoard.tsx
+++ b/frontend/src/saloon/SaloonBoard.tsx
@@ -1,0 +1,215 @@
+/**
+ * OFC board for one seat at the saloon table. VENDORED structure from
+ * components/PlayerBoard.tsx, restyled for the old-West theme and trimmed of
+ * multiplayer-only concerns (Fantasy Land, disconnects, ranks).
+ */
+import type { Board, Card, Rank } from './vendor/types.ts';
+import { HandRank, Row, ThreeCardHandRank } from './vendor/types.ts';
+import {
+  HAND_RANK_NAMES,
+  THREE_CARD_HAND_RANK_NAMES,
+  TOP_PAIR_ROYALTIES,
+} from './vendor/constants.ts';
+import { evaluate3CardHand, evaluate5CardHand } from './vendor/hand-evaluation.ts';
+import { calculateRoyalties } from './vendor/scoring.ts';
+import { SaloonCard, CARD_ASPECT } from './SaloonCard.tsx';
+
+function CardSlot({ card, widthPx, back }: { card: Card | null; widthPx: number; back?: boolean }) {
+  if (card || back) {
+    return <SaloonCard card={card} widthPx={widthPx} back={back} />;
+  }
+  return (
+    <div
+      className="border-2 border-dashed border-amber-200/25 bg-black/15"
+      style={{
+        width: widthPx,
+        height: Math.round(widthPx * CARD_ASPECT),
+        borderRadius: Math.max(2, Math.round(widthPx * 0.1)),
+      }}
+    />
+  );
+}
+
+function padRow(cards: Card[], size: number): (Card | null)[] {
+  const result: (Card | null)[] = [...cards];
+  while (result.length < size) result.push(null);
+  return result;
+}
+
+interface RowEvalInfo {
+  label: string;
+  royalty: boolean;
+}
+
+function rowEval(
+  row: 'top' | 'middle' | 'bottom',
+  board: Board,
+  royalties: { top: number; middle: number; bottom: number },
+): RowEvalInfo | null {
+  if (row === 'top') {
+    if (board.top.length < 3) return null;
+    const eval3 = evaluate3CardHand(board.top);
+    if (eval3.handRank === ThreeCardHandRank.HighCard) return null;
+    if (eval3.handRank === ThreeCardHandRank.Pair) {
+      const pairRank = eval3.kickers[0] as Rank;
+      if (!(pairRank in TOP_PAIR_ROYALTIES)) return null;
+    }
+    const name = THREE_CARD_HAND_RANK_NAMES[eval3.handRank];
+    const pts = royalties.top;
+    return { label: pts > 0 ? `${name} +${pts}` : name, royalty: pts > 0 };
+  } else {
+    const cards = row === 'middle' ? board.middle : board.bottom;
+    if (cards.length < 5) return null;
+    const eval5 = evaluate5CardHand(cards);
+    if (eval5.handRank === HandRank.HighCard) return null;
+    const name = HAND_RANK_NAMES[eval5.handRank];
+    const pts = royalties[row];
+    return { label: pts > 0 ? `${name} +${pts}` : name, royalty: pts > 0 };
+  }
+}
+
+function RowOverlay({ label, royalty, cardWidthPx }: { label: string; royalty: boolean; cardWidthPx: number }) {
+  return (
+    <div
+      className="absolute inset-0 flex items-center justify-center bg-black/60 pointer-events-none rounded z-[5]"
+      style={{ fontSize: Math.max(10, Math.round(cardWidthPx * 0.28)) }}
+    >
+      <span className={`font-bold drop-shadow-lg ${royalty ? 'text-yellow-300' : 'text-amber-50'}`}>{label}</span>
+    </div>
+  );
+}
+
+interface SaloonBoardProps {
+  board: Board;
+  name: string;
+  /** Line under the name, e.g. running points or chips. */
+  sub?: string;
+  avatar?: string;
+  fouled?: boolean;
+  /** It's this seat's turn to act. */
+  active?: boolean;
+  /** Number of face-down cards to show beside the name (a rival's dealt hand). */
+  ponderingCards?: number;
+  cardWidthPx: number;
+  onRowClick?: (row: Row) => void;
+  hasCardSelected?: boolean;
+  /** Count of trailing not-yet-submitted cards per row (tap to take back). */
+  pendingByRow?: { top: number; middle: number; bottom: number };
+  onUndoCard?: (row: Row, pendingIndex: number) => void;
+}
+
+export function SaloonBoard({
+  board, name, sub, avatar, fouled, active, ponderingCards = 0,
+  cardWidthPx, onRowClick, hasCardSelected, pendingByRow, onUndoCard,
+}: SaloonBoardProps) {
+  const topSlots = padRow(board.top, 3);
+  const middleSlots = padRow(board.middle, 5);
+  const bottomSlots = padRow(board.bottom, 5);
+
+  const pending = pendingByRow ?? { top: 0, middle: 0, bottom: 0 };
+
+  const renderSlot = (
+    rowKey: 'top' | 'middle' | 'bottom',
+    rowEnum: Row,
+    cards: Card[],
+    card: Card | null,
+    i: number,
+    key: string,
+  ) => {
+    const committed = cards.length - pending[rowKey];
+    const undoable = !!onUndoCard && card !== null && i >= committed && i < cards.length;
+    if (!undoable) return <CardSlot key={key} card={card} widthPx={cardWidthPx} />;
+    return (
+      <div
+        key={key}
+        onClick={(e) => { e.stopPropagation(); onUndoCard!(rowEnum, i - committed); }}
+        title="Tap to take this card back"
+        className="relative cursor-pointer hover:brightness-110 active:scale-95 transition-transform"
+        data-testid={`saloon-pending-${rowKey}-${i - committed}`}
+      >
+        <SaloonCard card={card} widthPx={cardWidthPx} />
+        <span className="absolute inset-0 rounded ring-2 ring-yellow-500/80 pointer-events-none" />
+      </div>
+    );
+  };
+
+  const rowClickable = (hasSpace: boolean) => !!onRowClick && !!hasCardSelected && hasSpace;
+
+  const gap = Math.max(2, Math.round(cardWidthPx * 0.06));
+  const boardPad = Math.max(4, Math.round(cardWidthPx * 0.12));
+  const headerFs = Math.max(9, Math.round(cardWidthPx * 0.24));
+  const boardMaxW = 5 * cardWidthPx + 4 * gap + 2 * boardPad + 4;
+
+  const rowClass = (clickable: boolean) => `
+    relative flex justify-center rounded px-1 py-0.5 transition-colors
+    ${clickable ? 'cursor-pointer bg-yellow-700/20 hover:bg-yellow-600/30 ring-1 ring-yellow-500/50' : ''}
+  `;
+
+  const royalties = calculateRoyalties(board);
+  const topEval = !fouled ? rowEval('top', board, royalties) : null;
+  const middleEval = !fouled ? rowEval('middle', board, royalties) : null;
+  const bottomEval = !fouled ? rowEval('bottom', board, royalties) : null;
+
+  return (
+    <div
+      className={`relative border-2 rounded overflow-hidden ${
+        active
+          ? 'border-yellow-500 bg-yellow-900/20 shadow-lg shadow-yellow-900/30'
+          : 'border-amber-900/60 bg-black/20'
+      }`}
+      style={{ padding: boardPad, maxWidth: boardMaxW }}
+    >
+      <div
+        className="text-center mb-1 text-amber-100 flex items-center justify-center gap-1 overflow-hidden whitespace-nowrap"
+        style={{ fontSize: headerFs, lineHeight: '1.2' }}
+      >
+        {avatar && <span className="flex-shrink-0">{avatar}</span>}
+        <span className="truncate font-bold">{name}</span>
+        {sub && <span className="text-amber-300/80 flex-shrink-0">{sub}</span>}
+        {fouled && <span className="text-red-400 font-bold flex-shrink-0">[FOUL]</span>}
+        {ponderingCards > 0 && (
+          <span className="flex gap-0.5 flex-shrink-0" aria-label={`${ponderingCards} cards dealt`}>
+            {Array.from({ length: ponderingCards }, (_, i) => (
+              <SaloonCard key={i} card={null} back widthPx={Math.round(cardWidthPx * 0.4)} />
+            ))}
+          </span>
+        )}
+      </div>
+
+      {/* Top row - 3 cards, centered with spacers to match 5-card row width */}
+      <div
+        data-testid="saloon-row-top"
+        onClick={rowClickable(board.top.length < 3) ? () => onRowClick!(Row.Top) : undefined}
+        className={`${rowClass(rowClickable(board.top.length < 3))} mb-1`}
+        style={{ gap }}
+      >
+        <div style={{ width: cardWidthPx }} />
+        {topSlots.map((card, i) => renderSlot('top', Row.Top, board.top, card, i, `top-${i}`))}
+        <div style={{ width: cardWidthPx }} />
+        {topEval && <RowOverlay label={topEval.label} royalty={topEval.royalty} cardWidthPx={cardWidthPx} />}
+      </div>
+
+      {/* Middle row - 5 cards */}
+      <div
+        data-testid="saloon-row-middle"
+        onClick={rowClickable(board.middle.length < 5) ? () => onRowClick!(Row.Middle) : undefined}
+        className={`${rowClass(rowClickable(board.middle.length < 5))} mb-1`}
+        style={{ gap }}
+      >
+        {middleSlots.map((card, i) => renderSlot('middle', Row.Middle, board.middle, card, i, `mid-${i}`))}
+        {middleEval && <RowOverlay label={middleEval.label} royalty={middleEval.royalty} cardWidthPx={cardWidthPx} />}
+      </div>
+
+      {/* Bottom row - 5 cards */}
+      <div
+        data-testid="saloon-row-bottom"
+        onClick={rowClickable(board.bottom.length < 5) ? () => onRowClick!(Row.Bottom) : undefined}
+        className={rowClass(rowClickable(board.bottom.length < 5))}
+        style={{ gap }}
+      >
+        {bottomSlots.map((card, i) => renderSlot('bottom', Row.Bottom, board.bottom, card, i, `bot-${i}`))}
+        {bottomEval && <RowOverlay label={bottomEval.label} royalty={bottomEval.royalty} cardWidthPx={cardWidthPx} />}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/saloon/SaloonCard.tsx
+++ b/frontend/src/saloon/SaloonCard.tsx
@@ -1,0 +1,88 @@
+/**
+ * Western-styled playing card for the Saloon mode. VENDORED layout from
+ * components/CardComponent.tsx, restyled: cream stock, classic two-color
+ * suits, plus a card-back variant for face-down deals.
+ */
+import type { CSSProperties } from 'react';
+import type { Card } from './vendor/types.ts';
+import { RANK_NAMES } from './vendor/constants.ts';
+
+const SUIT_SYMBOL: Record<string, string> = {
+  s: '♠',
+  h: '♥',
+  d: '♦',
+  c: '♣',
+};
+
+const SUIT_COLOR: Record<string, string> = {
+  s: 'text-stone-900',
+  c: 'text-stone-900',
+  h: 'text-red-700',
+  d: 'text-red-700',
+};
+
+export const CARD_ASPECT = 1.4;
+
+interface SaloonCardProps {
+  card: Card | null;
+  widthPx: number;
+  selected?: boolean;
+  onClick?: () => void;
+  /** Render a face-down card back (used while a rival ponders their deal). */
+  back?: boolean;
+}
+
+function frameStyle(w: number): CSSProperties {
+  return {
+    width: w,
+    height: Math.round(w * CARD_ASPECT),
+    borderRadius: Math.max(2, Math.round(w * 0.1)),
+  };
+}
+
+export function SaloonCard({ card, widthPx, selected, onClick, back }: SaloonCardProps) {
+  if (back) {
+    return (
+      <div
+        className="border-2 border-red-950 bg-red-900 bg-[repeating-linear-gradient(135deg,transparent,transparent_3px,rgba(255,215,130,0.18)_3px,rgba(255,215,130,0.18)_6px)] flex items-center justify-center"
+        style={frameStyle(widthPx)}
+      >
+        <span className="text-amber-200/70" style={{ fontSize: Math.round(widthPx * 0.4) }}>★</span>
+      </div>
+    );
+  }
+
+  if (!card) {
+    return (
+      <div
+        className="border-2 border-dashed border-amber-200/25 bg-black/20 flex items-center justify-center"
+        style={frameStyle(widthPx)}
+      >
+        <span className="text-amber-200/30">·</span>
+      </div>
+    );
+  }
+
+  const rank = RANK_NAMES[card.rank];
+  const rankFontSize = rank.length > 1 ? widthPx * 0.33 : widthPx * 0.43;
+
+  return (
+    <div
+      onClick={onClick}
+      className={`
+        border bg-amber-50 flex flex-col items-center justify-center
+        font-bold select-none transition-all ${SUIT_COLOR[card.suit]}
+        ${selected ? 'border-yellow-500 ring-2 ring-yellow-400 -translate-y-2 shadow-lg shadow-black/50' : 'border-stone-400'}
+        ${onClick ? 'cursor-pointer hover:brightness-105 hover:-translate-y-1' : 'cursor-default'}
+      `}
+      style={frameStyle(widthPx)}
+    >
+      <span style={{ fontSize: Math.max(7, Math.round(rankFontSize)), lineHeight: '1' }}>{rank}</span>
+      {widthPx >= 25 && (
+        <span style={{ fontSize: Math.max(5, Math.round(widthPx * 0.25)), lineHeight: '1' }}>
+          {SUIT_SYMBOL[card.suit]}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/saloon/SaloonCard.tsx
+++ b/frontend/src/saloon/SaloonCard.tsx
@@ -1,7 +1,7 @@
 /**
  * Western-styled playing card for the Saloon mode. VENDORED layout from
- * components/CardComponent.tsx, restyled: cream stock, classic two-color
- * suits, plus a card-back variant for face-down deals.
+ * components/CardComponent.tsx, restyled: cream stock, four-color suits,
+ * plus a card-back variant for face-down deals.
  */
 import type { CSSProperties } from 'react';
 import type { Card } from './vendor/types.ts';
@@ -14,11 +14,13 @@ const SUIT_SYMBOL: Record<string, string> = {
   c: '♣',
 };
 
+/** Four-color deck, same suit colors as multiplayer: spades black, hearts
+ *  red, diamonds blue, clubs green — on cream western card stock. */
 const SUIT_COLOR: Record<string, string> = {
   s: 'text-stone-900',
-  c: 'text-stone-900',
   h: 'text-red-700',
-  d: 'text-red-700',
+  d: 'text-blue-700',
+  c: 'text-green-700',
 };
 
 export const CARD_ASPECT = 1.4;

--- a/frontend/src/saloon/SaloonTable.tsx
+++ b/frontend/src/saloon/SaloonTable.tsx
@@ -1,0 +1,348 @@
+/**
+ * The saloon card table — plays one campaign match of traditional turn-based
+ * OFC Pineapple against the level's characters. Placement UX is vendored from
+ * the multiplayer MobileGamePage: tap a card, tap a row; the last card on
+ * streets 2-5 is discarded automatically; pending cards can be tapped to take
+ * back before the final card auto-submits the street.
+ */
+import { useEffect, useState } from 'react';
+import type { SaloonLevel } from './campaign.ts';
+import { SKILL_LABELS } from './campaign.ts';
+import {
+  applyPlacement,
+  createTable,
+  currentSeat,
+  heroWonMatch,
+  nextHand,
+  placementsRequired,
+  type TableState,
+} from './engine.ts';
+import { decideBotMove } from './bots.ts';
+import type { Board, Card, Row } from './vendor/types.ts';
+import { isFoul } from './vendor/scoring.ts';
+import { SaloonBoard } from './SaloonBoard.tsx';
+import { SaloonCard } from './SaloonCard.tsx';
+
+interface PendingPlacement {
+  card: Card;
+  row: Row;
+  handIndex: number;
+}
+
+interface SaloonTableProps {
+  level: SaloonLevel;
+  /** Called when the player leaves the table after the final hand. */
+  onMatchEnd: (heroPoints: number, won: boolean) => void;
+  /** Walk out mid-match (no settlement). */
+  onQuit: () => void;
+}
+
+const ROW_MAX: Record<Row, number> = { top: 3, middle: 5, bottom: 5 };
+
+export function SaloonTable({ level, onMatchEnd, onQuit }: SaloonTableProps) {
+  const [table, setTable] = useState<TableState>(() =>
+    createTable(
+      'You',
+      level.opponents.map((o) => ({ id: o.id, name: o.name, skill: o.skill })),
+      level.hands,
+    ),
+  );
+  const [pending, setPending] = useState<PendingPlacement[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+
+  const acting = table.phase === 'acting' ? currentSeat(table) : null;
+  const heroSeat = table.seats.find((s) => s.isHero)!;
+  const heroTurn = !!acting?.isHero;
+  const required = placementsRequired(table.street);
+
+  // Bots act on a short "thinking" delay so the table feels alive.
+  useEffect(() => {
+    if (table.phase !== 'acting') return;
+    const seat = table.seats[table.turnIdx];
+    if (seat.isHero) return;
+    const delay = 700 + Math.random() * 900;
+    const timer = setTimeout(() => {
+      setTable((cur) => {
+        if (cur.phase !== 'acting' || cur.seats[cur.turnIdx].isHero) return cur;
+        const move = decideBotMove(cur);
+        return applyPlacement(cur, move.placements, move.discard);
+      });
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [table]);
+
+  // Hero's dealt cards not yet placed this street.
+  const pendingIndices = new Set(pending.map((p) => p.handIndex));
+  const availableHand = heroTurn
+    ? heroSeat.hand
+        .map((card, handIndex) => ({ card, handIndex }))
+        .filter(({ handIndex }) => !pendingIndices.has(handIndex))
+    : [];
+
+  // Hero board with pending placements merged for display.
+  const heroBoard: Board = {
+    top: [...heroSeat.board.top],
+    middle: [...heroSeat.board.middle],
+    bottom: [...heroSeat.board.bottom],
+  };
+  for (const p of pending) heroBoard[p.row].push(p.card);
+
+  const pendingByRow = {
+    top: pending.filter((p) => p.row === 'top').length,
+    middle: pending.filter((p) => p.row === 'middle').length,
+    bottom: pending.filter((p) => p.row === 'bottom').length,
+  };
+
+  const submitStreet = (placements: PendingPlacement[]) => {
+    const placedIdx = new Set(placements.map((p) => p.handIndex));
+    const discardEntry =
+      table.street > 1
+        ? heroSeat.hand.map((card, idx) => ({ card, idx })).find(({ idx }) => !placedIdx.has(idx))
+        : null;
+    setTable(
+      applyPlacement(
+        table,
+        placements.map(({ card, row }) => ({ card, row })),
+        discardEntry?.card ?? null,
+      ),
+    );
+    setPending([]);
+    setSelectedIndex(null);
+  };
+
+  const handleRowClick = (row: Row) => {
+    if (!heroTurn || selectedIndex === null) return;
+    const selected = availableHand[selectedIndex];
+    if (!selected) return;
+    if (heroBoard[row].length >= ROW_MAX[row]) return;
+
+    const next = [...pending, { card: selected.card, row, handIndex: selected.handIndex }];
+    setSelectedIndex(null);
+    if (next.length === required) {
+      submitStreet(next);
+    } else {
+      setPending(next);
+    }
+  };
+
+  const handleUndoCard = (row: Row, pendingIndex: number) => {
+    const inRow = pending.filter((p) => p.row === row);
+    const target = inRow[pendingIndex];
+    if (!target) return;
+    setPending(pending.filter((p) => p !== target));
+    setSelectedIndex(null);
+  };
+
+  const handleQuit = () => {
+    if (window.confirm('Walk away from the table? This match will not count.')) {
+      onQuit();
+    }
+  };
+
+  const opponents = table.seats.filter((s) => !s.isHero);
+  const oppCardW = opponents.length > 1 ? 26 : 32;
+  const lastHandNet = (id: string) =>
+    table.lastResult?.players.find((p) => p.uid === id)?.netScore ?? 0;
+
+  const isLastHand = table.handNumber >= table.handsPerMatch;
+  const heroWon = heroWonMatch(table);
+  const money = (pts: number) => {
+    const dollars = pts * level.stake;
+    return `${dollars >= 0 ? '+' : '-'}$${Math.abs(dollars)}`;
+  };
+
+  return (
+    <div className="min-h-[100dvh] bg-stone-950 flex justify-center">
+      <div className="w-full max-w-[430px] min-h-[100dvh] bg-gradient-to-b from-stone-900 via-amber-950/40 to-stone-900 text-amber-100 flex flex-col">
+        {/* Header */}
+        <div className="border-b-2 border-amber-800/60 bg-black/30 px-3 py-2 flex items-center justify-between flex-shrink-0">
+          <div className="min-w-0">
+            <div className="font-serif font-bold text-amber-200 text-sm truncate">🤠 {level.location}</div>
+            <div className="text-[10px] text-amber-400/80">
+              Hand {table.handNumber}/{table.handsPerMatch} · Street {table.street}/5 · ${level.stake} a point
+            </div>
+          </div>
+          <button
+            onClick={handleQuit}
+            className="px-2 py-1 rounded border border-red-900 bg-red-950/60 text-red-300 text-[10px] flex-shrink-0"
+          >
+            Walk away
+          </button>
+        </div>
+
+        {/* Turn banner */}
+        <div
+          className={`text-center text-xs py-1 flex-shrink-0 ${
+            heroTurn ? 'bg-yellow-700/40 text-yellow-200 font-bold' : 'bg-black/20 text-amber-300/80'
+          }`}
+          data-testid="saloon-turn-banner"
+        >
+          {table.phase !== 'acting'
+            ? 'Showdown'
+            : heroTurn
+              ? table.street === 1
+                ? 'Your deal — set all 5 cards'
+                : 'Your turn — set 2, the last card hits the muck'
+              : `${acting!.name} is studying their cards…`}
+        </div>
+
+        {/* Opponents */}
+        <div className="flex-shrink-0 flex justify-center gap-2 px-2 py-2">
+          {opponents.map((seat) => {
+            const character = level.opponents.find((o) => o.id === seat.id);
+            return (
+              <SaloonBoard
+                key={seat.id}
+                board={seat.board}
+                name={seat.name}
+                avatar={character?.avatar}
+                sub={`(${seat.matchPoints >= 0 ? '+' : ''}${seat.matchPoints})`}
+                fouled={table.phase !== 'acting' && seat.fouled}
+                active={acting?.id === seat.id}
+                ponderingCards={acting?.id === seat.id ? seat.hand.length : 0}
+                cardWidthPx={oppCardW}
+              />
+            );
+          })}
+        </div>
+
+        {/* Hero board */}
+        <div className="flex-1 flex flex-col items-center justify-center px-2 min-h-0" data-testid="saloon-my-board">
+          <SaloonBoard
+            board={heroBoard}
+            name="You"
+            avatar="🤠"
+            sub={`(${heroSeat.matchPoints >= 0 ? '+' : ''}${heroSeat.matchPoints})`}
+            fouled={table.phase !== 'acting' ? heroSeat.fouled : isFoul(heroBoard)}
+            active={heroTurn}
+            cardWidthPx={42}
+            onRowClick={heroTurn ? handleRowClick : undefined}
+            hasCardSelected={selectedIndex !== null}
+            pendingByRow={pendingByRow}
+            onUndoCard={pending.length > 0 ? handleUndoCard : undefined}
+          />
+        </div>
+
+        {/* Hand area */}
+        <div className="flex-shrink-0 border-t-2 border-amber-800/60 bg-black/30 px-2 pt-2 pb-3 min-h-[110px]">
+          {heroTurn ? (
+            <>
+              <div className="text-center text-[10px] text-amber-400/80 mb-1.5">
+                {table.street === 1
+                  ? `Place ${required - pending.length} more`
+                  : pending.length < required
+                    ? `Place ${required - pending.length} of 3 — the leftover is your discard`
+                    : ''}
+              </div>
+              <div className="flex justify-center gap-2" data-testid="saloon-hand">
+                {availableHand.map(({ card }, i) => (
+                  <div key={`${card.rank}${card.suit}-${i}`} data-testid={`saloon-hand-card-${i}`}>
+                    <SaloonCard
+                      card={card}
+                      widthPx={52}
+                      selected={selectedIndex === i}
+                      onClick={() => setSelectedIndex(selectedIndex === i ? null : i)}
+                    />
+                  </div>
+                ))}
+              </div>
+            </>
+          ) : (
+            <div className="h-full flex items-center justify-center text-amber-500/60 text-xs italic pt-6">
+              {table.phase === 'acting' ? 'Waiting on the table…' : 'Tallying the damage…'}
+            </div>
+          )}
+        </div>
+
+        {/* Hand result overlay */}
+        {table.phase === 'hand_scored' && (
+          <div className="fixed inset-0 z-40 bg-black/80 flex items-center justify-center p-4">
+            <div className="w-full max-w-sm rounded-lg border-2 border-amber-700 bg-stone-900 p-4 shadow-2xl">
+              <h2 className="font-serif text-lg font-bold text-amber-200 text-center mb-3">
+                ♠ Hand {table.handNumber} Showdown ♠
+              </h2>
+              <div className="space-y-1.5 mb-4">
+                {[...table.seats]
+                  .sort((a, b) => b.matchPoints - a.matchPoints)
+                  .map((seat) => {
+                    const net = lastHandNet(seat.id);
+                    return (
+                      <div
+                        key={seat.id}
+                        className={`flex items-center justify-between rounded px-2 py-1.5 text-sm ${
+                          seat.isHero ? 'bg-yellow-900/30 border border-yellow-700/50' : 'bg-black/30'
+                        }`}
+                      >
+                        <span className="text-amber-100 truncate">
+                          {seat.isHero ? '🤠 You' : seat.name}
+                          {seat.fouled && <span className="text-red-400 text-xs ml-1">FOUL</span>}
+                        </span>
+                        <span className="flex items-baseline gap-2 flex-shrink-0">
+                          <span className={net >= 0 ? 'text-green-400' : 'text-red-400'}>
+                            {net >= 0 ? `+${net}` : net}
+                          </span>
+                          <span className="text-amber-400/70 text-xs">
+                            total {seat.matchPoints >= 0 ? `+${seat.matchPoints}` : seat.matchPoints}
+                          </span>
+                        </span>
+                      </div>
+                    );
+                  })}
+              </div>
+              <button
+                onClick={() => setTable(nextHand(table))}
+                data-testid="saloon-next-hand"
+                className="w-full py-2.5 rounded bg-amber-700 hover:bg-amber-600 text-white font-bold text-sm"
+              >
+                {isLastHand ? 'Cash out' : 'Deal the next hand'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Match over overlay */}
+        {table.phase === 'match_over' && (
+          <div className="fixed inset-0 z-50 bg-black/90 flex items-center justify-center p-4">
+            <div className="w-full max-w-sm rounded-lg border-2 border-amber-700 bg-stone-900 p-5 text-center shadow-2xl">
+              <div className="text-4xl mb-2">{heroWon ? '🏆' : '💀'}</div>
+              <h2 className="font-serif text-xl font-bold text-amber-200 mb-1">
+                {heroWon ? 'You cleaned out the table!' : `${level.location} got the best of you`}
+              </h2>
+              <p className="text-amber-400/80 text-sm mb-3">
+                {heroWon
+                  ? 'Word of your play is spreading down the trail.'
+                  : 'Dust yourself off and try again, stranger.'}
+              </p>
+              <div className="rounded bg-black/40 px-3 py-2 mb-4 text-sm">
+                <div className="flex justify-between text-amber-100">
+                  <span>Your points</span>
+                  <span className={heroSeat.matchPoints >= 0 ? 'text-green-400' : 'text-red-400'}>
+                    {heroSeat.matchPoints >= 0 ? `+${heroSeat.matchPoints}` : heroSeat.matchPoints}
+                  </span>
+                </div>
+                <div className="flex justify-between text-amber-100">
+                  <span>At ${level.stake} a point</span>
+                  <span className={heroSeat.matchPoints >= 0 ? 'text-green-400' : 'text-red-400'}>
+                    {money(heroSeat.matchPoints)}
+                  </span>
+                </div>
+              </div>
+              <button
+                onClick={() => onMatchEnd(heroSeat.matchPoints, heroWon)}
+                data-testid="saloon-match-end"
+                className="w-full py-2.5 rounded bg-amber-700 hover:bg-amber-600 text-white font-bold text-sm"
+              >
+                {heroWon ? 'Take your winnings' : 'Back to the trail'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Roster footer */}
+        <div className="flex-shrink-0 border-t border-amber-900/40 bg-black/40 px-3 py-1 text-[9px] text-amber-500/60 text-center">
+          {level.opponents.map((o) => `${o.avatar} ${o.name} · ${SKILL_LABELS[o.skill]}`).join('   ')}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/saloon/bots.ts
+++ b/frontend/src/saloon/bots.ts
@@ -1,0 +1,36 @@
+/**
+ * Bot decision layer for the Saloon: maps a character's skill tier to the
+ * vendored greedy strategy with score jitter. Greenhorns make real mistakes
+ * (including the occasional foul); outlaws play the strategy straight.
+ */
+import type { TableState } from './engine.ts';
+import { currentSeat } from './engine.ts';
+import type { BotSkill, SeatPlacement } from './engine.ts';
+import type { Card } from './vendor/types.ts';
+import { botPlaceInitialDeal, botPlaceStreet } from './vendor/bot-strategy.ts';
+
+/** Score jitter per skill tier — tuned against scoreBoard's scale, where
+ *  ~600 is a made-tier inversion and ~5000 a near-certain foul. */
+const SKILL_JITTER: Record<BotSkill, number> = {
+  greenhorn: 900,
+  gunslinger: 250,
+  outlaw: 0,
+};
+
+export interface BotMove {
+  placements: SeatPlacement[];
+  discard: Card | null;
+}
+
+/** Decide the acting bot's move for the current street. */
+export function decideBotMove(state: TableState): BotMove {
+  const seat = currentSeat(state);
+  const jitter = SKILL_JITTER[seat.skill ?? 'outlaw'];
+  const decision = state.street === 1
+    ? botPlaceInitialDeal(seat.hand, seat.board, jitter)
+    : botPlaceStreet(seat.hand, seat.board, jitter);
+  return {
+    placements: decision.placements,
+    discard: decision.discard ?? null,
+  };
+}

--- a/frontend/src/saloon/campaign.ts
+++ b/frontend/src/saloon/campaign.ts
@@ -1,0 +1,205 @@
+/**
+ * The Frontier Trail — campaign ladder for the single-player Saloon mode.
+ *
+ * Governor-of-Poker structure: a trail of old-West locales, each guarded by
+ * one or two named characters. Beat the table (finish with the most points)
+ * to unlock the next stop. Stakes and table size climb as you go; winnings
+ * are tracked as a dollar bankroll in localStorage.
+ */
+import type { BotSkill } from './engine.ts';
+
+export interface SaloonCharacter {
+  id: string;
+  name: string;
+  /** Emoji avatar — keeps the art budget at zero. */
+  avatar: string;
+  skill: BotSkill;
+  blurb: string;
+}
+
+export interface SaloonLevel {
+  id: number;
+  /** Locale name shown on the trail and table header. */
+  location: string;
+  /** Dollars per point. */
+  stake: number;
+  /** Hands per match. */
+  hands: number;
+  opponents: SaloonCharacter[];
+  tagline: string;
+}
+
+export const SKILL_LABELS: Record<BotSkill, string> = {
+  greenhorn: 'Greenhorn',
+  gunslinger: 'Gunslinger',
+  outlaw: 'Outlaw',
+};
+
+export const LEVELS: SaloonLevel[] = [
+  {
+    id: 1,
+    location: 'Dusty Gulch',
+    stake: 1,
+    hands: 3,
+    tagline: 'A one-mule town where the cards are stickier than the floor.',
+    opponents: [
+      {
+        id: 'ted',
+        name: 'Tumbleweed Ted',
+        avatar: '🌵',
+        skill: 'greenhorn',
+        blurb: 'Learned poker off the back of a feed catalog. Folds to a stiff breeze.',
+      },
+    ],
+  },
+  {
+    id: 2,
+    location: 'Rattlesnake Creek',
+    stake: 2,
+    hands: 4,
+    tagline: 'Mind the snakes. The two-legged kind mostly.',
+    opponents: [
+      {
+        id: 'kate',
+        name: 'Calamity Kate',
+        avatar: '🐍',
+        skill: 'gunslinger',
+        blurb: 'Quick with a grin, quicker with a queen. Counts cards out loud to rattle you.',
+      },
+    ],
+  },
+  {
+    id: 3,
+    location: 'Silver City Saloon',
+    stake: 3,
+    hands: 4,
+    tagline: 'Your first full table. Three players, one deck, no friends.',
+    opponents: [
+      {
+        id: 'doc',
+        name: 'Doc Maybury',
+        avatar: '🥃',
+        skill: 'gunslinger',
+        blurb: 'Pulls teeth by day, pulls flushes by night.',
+      },
+      {
+        id: 'sam',
+        name: 'Snake-Eye Sam',
+        avatar: '🎲',
+        skill: 'gunslinger',
+        blurb: 'Banned from every dice table west of the Pecos. Cards were the compromise.',
+      },
+    ],
+  },
+  {
+    id: 4,
+    location: 'Deadwood Card Hall',
+    stake: 5,
+    hands: 5,
+    tagline: 'Where the stakes get tall and the stories taller.',
+    opponents: [
+      {
+        id: 'brodie',
+        name: 'Marshal Brodie',
+        avatar: '⭐',
+        skill: 'outlaw',
+        blurb: 'Keeps the peace, takes your money. In that order.',
+      },
+      {
+        id: 'bart',
+        name: 'Black-Hat Bart',
+        avatar: '🎩',
+        skill: 'outlaw',
+        blurb: "Nobody's seen him blink. Nobody's seen him foul, either.",
+      },
+    ],
+  },
+  {
+    id: 5,
+    location: "The Governor's Parlor",
+    stake: 10,
+    hands: 6,
+    tagline: 'Velvet drapes, crystal glasses, and the coldest deck in the territory.',
+    opponents: [
+      {
+        id: 'governor',
+        name: 'The Governor',
+        avatar: '🦅',
+        skill: 'outlaw',
+        blurb: 'Runs the territory from behind a card table. Beat him and the trail is yours.',
+      },
+    ],
+  },
+];
+
+// ---- Progress persistence ----
+
+export interface SaloonProgress {
+  bankroll: number;
+  /** Highest level id the player may attempt. */
+  unlocked: number;
+  /** Match wins per level id. */
+  wins: Record<number, number>;
+}
+
+const PROGRESS_KEY = 'saloon_progress_v1';
+export const STARTING_BANKROLL = 100;
+
+export function defaultProgress(): SaloonProgress {
+  return { bankroll: STARTING_BANKROLL, unlocked: 1, wins: {} };
+}
+
+export function loadProgress(): SaloonProgress {
+  try {
+    const raw = localStorage.getItem(PROGRESS_KEY);
+    if (!raw) return defaultProgress();
+    const parsed = JSON.parse(raw) as Partial<SaloonProgress>;
+    return {
+      bankroll: typeof parsed.bankroll === 'number' ? parsed.bankroll : STARTING_BANKROLL,
+      unlocked: typeof parsed.unlocked === 'number' ? parsed.unlocked : 1,
+      wins: parsed.wins && typeof parsed.wins === 'object' ? parsed.wins : {},
+    };
+  } catch {
+    return defaultProgress();
+  }
+}
+
+export function saveProgress(progress: SaloonProgress): void {
+  try {
+    localStorage.setItem(PROGRESS_KEY, JSON.stringify(progress));
+  } catch {
+    // Private browsing / quota — progress just won't persist.
+  }
+}
+
+export function resetProgress(): SaloonProgress {
+  const fresh = defaultProgress();
+  saveProgress(fresh);
+  return fresh;
+}
+
+/**
+ * Apply a finished match to progress: settle winnings at the level's stake
+ * and unlock the next stop on a win.
+ */
+export function settleMatch(
+  progress: SaloonProgress,
+  level: SaloonLevel,
+  heroPoints: number,
+  won: boolean,
+): SaloonProgress {
+  const next: SaloonProgress = {
+    bankroll: progress.bankroll + heroPoints * level.stake,
+    unlocked: progress.unlocked,
+    wins: { ...progress.wins },
+  };
+  if (won) {
+    next.wins[level.id] = (next.wins[level.id] ?? 0) + 1;
+    const after = LEVELS.find((l) => l.id === level.id + 1);
+    if (after && next.unlocked < after.id) {
+      next.unlocked = after.id;
+    }
+  }
+  saveProgress(next);
+  return next;
+}

--- a/frontend/src/saloon/engine.test.ts
+++ b/frontend/src/saloon/engine.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyPlacement,
+  createTable,
+  currentSeat,
+  heroWonMatch,
+  nextHand,
+  placementsRequired,
+  startHand,
+  type TableState,
+} from './engine.ts';
+import { decideBotMove } from './bots.ts';
+import { createDeck } from './vendor/deck.ts';
+import type { Card, Row } from './vendor/types.ts';
+
+/** Place the acting seat's dealt cards legally-shaped (5 on street 1, 2+discard after),
+ *  filling bottom → middle → top in dealt order. */
+function autoPlace(state: TableState): TableState {
+  const seat = currentSeat(state);
+  const required = placementsRequired(state.street);
+  const order: Row[] = ['bottom', 'middle', 'top'];
+  const max: Record<Row, number> = { bottom: 5, middle: 5, top: 3 };
+  const counts: Record<Row, number> = {
+    bottom: seat.board.bottom.length,
+    middle: seat.board.middle.length,
+    top: seat.board.top.length,
+  };
+  const placements = seat.hand.slice(0, required).map((card) => {
+    const row = order.find((r) => counts[r] < max[r])!;
+    counts[row] += 1;
+    return { card, row };
+  });
+  const discard = state.street === 1 ? null : seat.hand[required];
+  return applyPlacement(state, placements, discard);
+}
+
+function newTable(opponentCount = 1, hands = 2): TableState {
+  const opponents = Array.from({ length: opponentCount }, (_, i) => ({
+    id: `bot${i}`,
+    name: `Bot ${i}`,
+    skill: 'outlaw' as const,
+  }));
+  return createTable('Hero', opponents, hands);
+}
+
+describe('createTable / startHand', () => {
+  it('seats the hero first and deals them 5 cards from the shared deck', () => {
+    const state = newTable(2);
+    expect(state.seats).toHaveLength(3);
+    expect(state.seats[0].isHero).toBe(true);
+    expect(state.buttonIdx).toBe(2);
+    expect(state.turnIdx).toBe(0); // left of button = hero
+    expect(currentSeat(state).hand).toHaveLength(5);
+    expect(state.deck).toHaveLength(47); // one shared deck
+    expect(state.seats[1].hand).toHaveLength(0); // others wait their turn
+  });
+
+  it('rejects tables outside 2-3 players', () => {
+    expect(() => createTable('Hero', [], 1)).toThrow();
+    expect(() =>
+      createTable(
+        'Hero',
+        [
+          { id: 'a', name: 'A', skill: 'outlaw' },
+          { id: 'b', name: 'B', skill: 'outlaw' },
+          { id: 'c', name: 'C', skill: 'outlaw' },
+        ],
+        1,
+      ),
+    ).toThrow();
+  });
+
+  it('accepts a rigged deck for deterministic hands', () => {
+    const rigged = createDeck(); // unshuffled: clubs 2..A, diamonds, hearts, spades
+    const state = startHand(newTable(1), rigged);
+    expect(currentSeat(state).hand).toEqual(rigged.slice(0, 5));
+    expect(state.deck).toEqual(rigged.slice(5));
+  });
+});
+
+describe('turn order and streets', () => {
+  it('passes the turn clockwise and deals each seat on their turn', () => {
+    let state = newTable(2); // hero, bot0, bot1; button on bot1
+    expect(state.turnIdx).toBe(0);
+
+    state = autoPlace(state); // hero places 5
+    expect(state.turnIdx).toBe(1);
+    expect(state.street).toBe(1);
+    expect(currentSeat(state).hand).toHaveLength(5);
+    expect(state.seats[0].hand).toHaveLength(0);
+
+    state = autoPlace(state); // bot0 places 5
+    expect(state.turnIdx).toBe(2);
+
+    state = autoPlace(state); // bot1 (button) places 5 → street 2
+    expect(state.street).toBe(2);
+    expect(state.turnIdx).toBe(0);
+    expect(currentSeat(state).hand).toHaveLength(3); // pineapple deal
+  });
+
+  it('players never receive a card another seat already got', () => {
+    let state = newTable(2);
+    const seen = new Set<string>();
+    const key = (c: Card) => `${c.rank}${c.suit}`;
+    // Walk the entire hand; collect every dealt card.
+    while (state.phase === 'acting') {
+      for (const c of currentSeat(state).hand) {
+        expect(seen.has(key(c))).toBe(false);
+        seen.add(key(c));
+      }
+      state = autoPlace(state);
+    }
+    // 3 players × (5 + 4×3) = 51 distinct cards dealt
+    expect(seen.size).toBe(51);
+  });
+
+  it('validates placements come from the dealt hand', () => {
+    const state = newTable(1);
+    const hand = currentSeat(state).hand;
+    const notDealt: Card = state.deck[0];
+    expect(() =>
+      applyPlacement(
+        state,
+        [
+          { card: notDealt, row: 'bottom' },
+          { card: hand[1], row: 'bottom' },
+          { card: hand[2], row: 'middle' },
+          { card: hand[3], row: 'middle' },
+          { card: hand[4], row: 'top' },
+        ],
+        null,
+      ),
+    ).toThrow(/not in dealt hand/);
+  });
+
+  it('requires a discard on streets 2-5 and none on street 1', () => {
+    let state = newTable(1);
+    const hand = currentSeat(state).hand;
+    expect(() =>
+      applyPlacement(
+        state,
+        hand.map((card) => ({ card, row: 'bottom' as Row })).slice(0, 5),
+        hand[0],
+      ),
+    ).toThrow(/No discard/);
+
+    state = autoPlace(state); // hero street 1
+    state = autoPlace(state); // bot street 1 → street 2, hero dealt 3
+    const street2Hand = currentSeat(state).hand;
+    expect(() =>
+      applyPlacement(
+        state,
+        [
+          { card: street2Hand[0], row: 'middle' },
+          { card: street2Hand[1], row: 'middle' },
+        ],
+        null,
+      ),
+    ).toThrow(/require a discard/);
+  });
+});
+
+describe('hand scoring and match flow', () => {
+  it('scores the hand after street 5 with zero-sum points', () => {
+    let state = newTable(2);
+    while (state.phase === 'acting') {
+      state = autoPlace(state);
+    }
+    expect(state.phase).toBe('hand_scored');
+    expect(state.lastResult).not.toBeNull();
+    const sum = state.seats.reduce((s, seat) => s + seat.matchPoints, 0);
+    expect(sum).toBe(0);
+    // Every board is complete
+    for (const seat of state.seats) {
+      expect(seat.board.top).toHaveLength(3);
+      expect(seat.board.middle).toHaveLength(5);
+      expect(seat.board.bottom).toHaveLength(5);
+    }
+  });
+
+  it('rotates the button between hands and ends the match after the last hand', () => {
+    let state = newTable(1, 2);
+    const firstButton = state.buttonIdx;
+    while (state.phase === 'acting') state = autoPlace(state);
+    state = nextHand(state);
+    expect(state.phase).toBe('acting');
+    expect(state.handNumber).toBe(2);
+    expect(state.buttonIdx).toBe((firstButton + 1) % 2);
+    // New hand: first to act is left of the new button
+    expect(state.turnIdx).toBe((state.buttonIdx + 1) % 2);
+
+    while (state.phase === 'acting') state = autoPlace(state);
+    state = nextHand(state);
+    expect(state.phase).toBe('match_over');
+  });
+
+  it('heroWonMatch requires strictly more points than every opponent', () => {
+    const state = newTable(2, 1);
+    state.seats[0].matchPoints = 5;
+    state.seats[1].matchPoints = 5;
+    state.seats[2].matchPoints = -10;
+    expect(heroWonMatch(state)).toBe(false);
+    state.seats[1].matchPoints = 4;
+    expect(heroWonMatch(state)).toBe(true);
+  });
+});
+
+describe('bot play', () => {
+  it.each(['greenhorn', 'gunslinger', 'outlaw'] as const)(
+    '%s bots complete full matches legally',
+    (skill) => {
+      let state = createTable('Hero', [
+        { id: 'a', name: 'A', skill },
+        { id: 'b', name: 'B', skill },
+      ], 2);
+      // Let bots play every seat (including the hero's) to exercise the
+      // strategy across all positions.
+      for (let guard = 0; guard < 200 && state.phase !== 'match_over'; guard++) {
+        if (state.phase === 'acting') {
+          const move = decideBotMove(state);
+          state = applyPlacement(state, move.placements, move.discard);
+        } else {
+          state = nextHand(state);
+        }
+      }
+      expect(state.phase).toBe('match_over');
+      const sum = state.seats.reduce((s, seat) => s + seat.matchPoints, 0);
+      expect(sum).toBe(0);
+    },
+  );
+});

--- a/frontend/src/saloon/engine.ts
+++ b/frontend/src/saloon/engine.ts
@@ -1,0 +1,303 @@
+/**
+ * Single-player Saloon engine — TRADITIONAL table OFC Pineapple.
+ *
+ * Unlike the multiplayer mode (per-player decks, simultaneous placement),
+ * this is the classic table game:
+ *  - ONE shared 52-card deck per hand
+ *  - Max 3 players at the table (3 × 17 cards dealt = 51 ≤ 52)
+ *  - TURN-BASED: play proceeds clockwise from the seat left of the button;
+ *    each player sees everything placed before them (discards stay hidden)
+ *  - Initial street: 5 cards, place all 5. Streets 2-5: 3 cards, place 2,
+ *    discard 1 face-down.
+ *  - After street 5 the hand is scored pairwise (rows, scoop, royalties,
+ *    fouls) and the button rotates.
+ *
+ * Pure state-transition functions — no timers, no IO. The UI (or a test)
+ * drives it by calling applyPlacement for whoever `currentSeat` points at.
+ */
+import type { Board, Card, Row, ScoringResult } from './vendor/types.ts';
+import {
+  FIVE_CARD_ROW_SIZE,
+  INITIAL_DEAL_COUNT,
+  MAX_TABLE_PLAYERS,
+  STREET_DEAL_COUNT,
+  STREET_PLACE_COUNT,
+  TOP_ROW_SIZE,
+  TOTAL_STREETS,
+} from './vendor/constants.ts';
+import { createShuffledDeck, dealCards } from './vendor/deck.ts';
+import { isFoul, scoreAllPlayers } from './vendor/scoring.ts';
+
+export type BotSkill = 'greenhorn' | 'gunslinger' | 'outlaw';
+
+export interface TableSeat {
+  id: string;
+  name: string;
+  isHero: boolean;
+  /** Bot skill tier; undefined for the hero. */
+  skill?: BotSkill;
+  board: Board;
+  /** Cards dealt to this seat, awaiting placement (only while it's their turn). */
+  hand: Card[];
+  /** Cumulative points across the match so far. */
+  matchPoints: number;
+  /** Whether this seat fouled the last scored hand. */
+  fouled: boolean;
+}
+
+export type TablePhase = 'acting' | 'hand_scored' | 'match_over';
+
+export interface TableState {
+  seats: TableSeat[];
+  deck: Card[];
+  /** Dealer button seat index; first to act is the seat to its left. */
+  buttonIdx: number;
+  /** Seat index whose turn it is to place (valid while phase === 'acting'). */
+  turnIdx: number;
+  /** 1 = initial five-card street, 2-5 = pineapple streets. */
+  street: number;
+  /** 1-based hand counter within the match. */
+  handNumber: number;
+  handsPerMatch: number;
+  phase: TablePhase;
+  /** Pairwise scoring of the last completed hand (set while 'hand_scored' / 'match_over'). */
+  lastResult: ScoringResult | null;
+}
+
+export interface SeatPlacement {
+  card: Card;
+  row: Row;
+}
+
+function emptyBoard(): Board {
+  return { top: [], middle: [], bottom: [] };
+}
+
+function cloneSeat(seat: TableSeat): TableSeat {
+  return {
+    ...seat,
+    board: {
+      top: [...seat.board.top],
+      middle: [...seat.board.middle],
+      bottom: [...seat.board.bottom],
+    },
+    hand: [...seat.hand],
+  };
+}
+
+function cloneState(state: TableState): TableState {
+  return {
+    ...state,
+    seats: state.seats.map(cloneSeat),
+    deck: [...state.deck],
+  };
+}
+
+export function currentSeat(state: TableState): TableSeat {
+  return state.seats[state.turnIdx];
+}
+
+/** Cards a seat must place this street (5 on the initial deal, 2 after). */
+export function placementsRequired(street: number): number {
+  return street === 1 ? INITIAL_DEAL_COUNT : STREET_PLACE_COUNT;
+}
+
+/**
+ * Create a fresh table. Hero always sits at seat 0; the button starts on the
+ * last seat so the hero acts first on hand 1.
+ */
+export function createTable(
+  heroName: string,
+  opponents: { id: string; name: string; skill: BotSkill }[],
+  handsPerMatch: number,
+): TableState {
+  if (opponents.length < 1 || opponents.length + 1 > MAX_TABLE_PLAYERS) {
+    throw new Error(`Table seats 2-${MAX_TABLE_PLAYERS} players`);
+  }
+  const seats: TableSeat[] = [
+    {
+      id: 'hero',
+      name: heroName,
+      isHero: true,
+      board: emptyBoard(),
+      hand: [],
+      matchPoints: 0,
+      fouled: false,
+    },
+    ...opponents.map((o) => ({
+      id: o.id,
+      name: o.name,
+      isHero: false,
+      skill: o.skill,
+      board: emptyBoard(),
+      hand: [],
+      matchPoints: 0,
+      fouled: false,
+    })),
+  ];
+
+  const state: TableState = {
+    seats,
+    deck: [],
+    buttonIdx: seats.length - 1,
+    turnIdx: 0,
+    street: 1,
+    handNumber: 1,
+    handsPerMatch,
+    phase: 'acting',
+    lastResult: null,
+  };
+  return startHand(state);
+}
+
+/**
+ * Start (or restart) the current hand: fresh shuffled shared deck, clear
+ * boards, street 1, and deal 5 cards to the seat left of the button.
+ * Pass `deck` to rig the shuffle in tests.
+ */
+export function startHand(state: TableState, deck?: Card[]): TableState {
+  const next = cloneState(state);
+  next.deck = deck ? [...deck] : createShuffledDeck();
+  for (const seat of next.seats) {
+    seat.board = emptyBoard();
+    seat.hand = [];
+    seat.fouled = false;
+  }
+  next.street = 1;
+  next.phase = 'acting';
+  next.lastResult = null;
+  next.turnIdx = (next.buttonIdx + 1) % next.seats.length;
+
+  const { dealt, remaining } = dealCards(next.deck, INITIAL_DEAL_COUNT);
+  next.seats[next.turnIdx].hand = dealt;
+  next.deck = remaining;
+  return next;
+}
+
+const ROW_MAX: Record<Row, number> = {
+  top: TOP_ROW_SIZE,
+  middle: FIVE_CARD_ROW_SIZE,
+  bottom: FIVE_CARD_ROW_SIZE,
+};
+
+function sameCard(a: Card, b: Card): boolean {
+  return a.suit === b.suit && a.rank === b.rank;
+}
+
+/**
+ * Apply the acting seat's placements (and discard, on streets 2-5), then
+ * advance the table: deal to the next seat, or advance the street, or score
+ * the hand after street 5.
+ */
+export function applyPlacement(
+  state: TableState,
+  placements: SeatPlacement[],
+  discard: Card | null,
+): TableState {
+  if (state.phase !== 'acting') {
+    throw new Error(`Cannot place in phase ${state.phase}`);
+  }
+  const required = placementsRequired(state.street);
+  if (placements.length !== required) {
+    throw new Error(`Street ${state.street} requires ${required} placements`);
+  }
+  if (state.street === 1 && discard !== null) {
+    throw new Error('No discard on the initial street');
+  }
+  if (state.street > 1 && discard === null) {
+    throw new Error('Streets 2-5 require a discard');
+  }
+
+  const next = cloneState(state);
+  const seat = next.seats[next.turnIdx];
+
+  // Every placed/discarded card must come from the dealt hand, each used once.
+  const handPool = [...seat.hand];
+  const takeFromHand = (card: Card) => {
+    const idx = handPool.findIndex((c) => sameCard(c, card));
+    if (idx === -1) {
+      throw new Error('Card not in dealt hand');
+    }
+    handPool.splice(idx, 1);
+  };
+  for (const p of placements) takeFromHand(p.card);
+  if (discard) takeFromHand(discard);
+  if (handPool.length !== 0) {
+    throw new Error('All dealt cards must be placed or discarded');
+  }
+
+  for (const p of placements) {
+    if (seat.board[p.row].length >= ROW_MAX[p.row]) {
+      throw new Error(`Row ${p.row} is full`);
+    }
+    seat.board[p.row].push(p.card);
+  }
+  seat.hand = [];
+
+  // Advance: next seat clockwise; when action returns to the first seat
+  // (left of the button), the street is over.
+  const firstToAct = (next.buttonIdx + 1) % next.seats.length;
+  const nextIdx = (next.turnIdx + 1) % next.seats.length;
+
+  if (nextIdx === firstToAct) {
+    // Street complete
+    if (next.street >= TOTAL_STREETS) {
+      return scoreHand(next);
+    }
+    next.street += 1;
+  }
+
+  next.turnIdx = nextIdx;
+  const { dealt, remaining } = dealCards(
+    next.deck,
+    next.street === 1 ? INITIAL_DEAL_COUNT : STREET_DEAL_COUNT,
+  );
+  next.seats[next.turnIdx].hand = dealt;
+  next.deck = remaining;
+  return next;
+}
+
+/** Score the completed hand pairwise and move to 'hand_scored'. */
+function scoreHand(state: TableState): TableState {
+  const boards = new Map<string, Board>();
+  const fouls = new Map<string, boolean>();
+  for (const seat of state.seats) {
+    boards.set(seat.id, seat.board);
+    fouls.set(seat.id, isFoul(seat.board));
+  }
+  const result = scoreAllPlayers(boards, fouls);
+  for (const score of result.players) {
+    const seat = state.seats.find((s) => s.id === score.uid)!;
+    seat.fouled = score.fouled;
+    seat.matchPoints += score.netScore;
+  }
+  state.lastResult = result;
+  state.phase = 'hand_scored';
+  return state;
+}
+
+/**
+ * Move on from a scored hand: rotate the button and deal the next hand, or
+ * end the match when all hands have been played.
+ * Pass `deck` to rig the next hand's shuffle in tests.
+ */
+export function nextHand(state: TableState, deck?: Card[]): TableState {
+  if (state.phase !== 'hand_scored') {
+    throw new Error(`Cannot advance from phase ${state.phase}`);
+  }
+  if (state.handNumber >= state.handsPerMatch) {
+    const next = cloneState(state);
+    next.phase = 'match_over';
+    return next;
+  }
+  const next = cloneState(state);
+  next.handNumber += 1;
+  next.buttonIdx = (next.buttonIdx + 1) % next.seats.length;
+  return startHand(next, deck);
+}
+
+/** The hero wins the match by finishing with strictly more points than every opponent. */
+export function heroWonMatch(state: TableState): boolean {
+  const hero = state.seats.find((s) => s.isHero)!;
+  return state.seats.every((s) => s.isHero || s.matchPoints < hero.matchPoints);
+}

--- a/frontend/src/saloon/vendor/bot-strategy.ts
+++ b/frontend/src/saloon/vendor/bot-strategy.ts
@@ -1,0 +1,356 @@
+/**
+ * VENDORED from dealer/src/bot-strategy.ts for the single-player Saloon mode,
+ * with one addition: an optional `jitter` parameter on both entry points.
+ * Jitter adds uniform random noise to each candidate's score before picking
+ * the best one — that's how campaign characters get skill tiers (a greenhorn
+ * plays with heavy jitter and makes real mistakes; an outlaw plays the
+ * strategy straight).
+ *
+ * Base strategy: greedy per-street placement scored by `scoreBoard`, whose
+ * dominant term is FOUL AVOIDANCE. Streets 2-5 brute-force all
+ * (discard, row-assignment) options.
+ */
+import type { Card, Board, Row } from './types.ts';
+import { TOP_ROW_SIZE, FIVE_CARD_ROW_SIZE } from './constants.ts';
+import { isFoul } from './scoring.ts';
+import { compareRows } from './hand-evaluation.ts';
+
+export interface BotPlacement {
+  card: Card;
+  row: Row;
+}
+
+export interface BotDecision {
+  placements: BotPlacement[];
+  discard?: Card;
+}
+
+const ROW_MAX: Record<Row, number> = {
+  top: TOP_ROW_SIZE,
+  middle: FIVE_CARD_ROW_SIZE,
+  bottom: FIVE_CARD_ROW_SIZE,
+};
+
+const ROWS: Row[] = ['bottom', 'middle', 'top'];
+
+function rowSpace(board: Board, row: Row): number {
+  return ROW_MAX[row] - board[row].length;
+}
+
+/** Average rank of cards in a row (0 if empty). */
+function avgRank(cards: Card[]): number {
+  if (cards.length === 0) return 0;
+  return cards.reduce((sum, c) => sum + c.rank, 0) / cards.length;
+}
+
+/** Count how many cards in the row share a rank with the given card. */
+function pairCount(card: Card, rowCards: Card[]): number {
+  return rowCards.filter((c) => c.rank === card.rank).length;
+}
+
+/** Count how many cards in the row share a suit with the given card. */
+function suitCount(card: Card, rowCards: Card[]): number {
+  return rowCards.filter((c) => c.suit === card.suit).length;
+}
+
+/** Uniform noise in [-jitter, +jitter]. */
+function noise(jitter: number): number {
+  if (jitter <= 0) return 0;
+  return (Math.random() * 2 - 1) * jitter;
+}
+
+/**
+ * Rough made-hand tier from rank multiplicity (works on partial rows), aligned
+ * with HandRank ordering: high card 0, pair 1, two pair 2, trips 3, full house
+ * 6, quads 7. A complete 5-card flush counts as 5. Straights/flush draws are
+ * ignored — pairs in the wrong row are the dominant foul driver this guards.
+ */
+function madeTier(cards: Card[]): number {
+  if (cards.length === 0) return 0;
+  const m = new Map<number, number>();
+  for (const c of cards) m.set(c.rank, (m.get(c.rank) ?? 0) + 1);
+  const counts = [...m.values()].sort((a, b) => b - a);
+  const flush = cards.length === 5 && cards.every((c) => c.suit === cards[0].suit);
+  let straight = false;
+  if (cards.length === 5 && m.size === 5) {
+    const r = [...m.keys()].sort((a, b) => a - b);
+    straight = r[4] - r[0] === 4 || (r[0] === 2 && r[3] === 5 && r[4] === 14);
+  }
+  if (flush && straight) return 8;
+  if (counts[0] >= 4) return 7;
+  if (counts[0] === 3 && (counts[1] ?? 0) >= 2) return 6;
+  if (flush) return 5;
+  if (straight) return 4;
+  if (counts[0] === 3) return 3;
+  if (counts[0] === 2 && (counts[1] ?? 0) === 2) return 2;
+  if (counts[0] === 2) return 1;
+  return 0;
+}
+
+/**
+ * Score a board state. Higher is better.
+ * Rewards: high cards on bottom, low cards on top, pairs, flush draws.
+ * Penalizes: row ordering violations (bottom avg < middle avg, etc.)
+ */
+function scoreBoard(board: Board): number {
+  let score = 0;
+
+  // --- Foul avoidance (the dominant term) ---
+  const bottomFull = board.bottom.length === FIVE_CARD_ROW_SIZE;
+  const middleFull = board.middle.length === FIVE_CARD_ROW_SIZE;
+  const topFull = board.top.length === TOP_ROW_SIZE;
+
+  if (bottomFull && middleFull && topFull) {
+    if (isFoul(board)) return -100000;
+    score += 200; // a completed, legal board is the goal
+  }
+  // Bottom must be >= middle: if both complete and that's violated, near-fatal.
+  if (bottomFull && middleFull && compareRows(board.bottom, board.middle, false) < 0) {
+    score -= 5000;
+  }
+
+  const bottomAvg = avgRank(board.bottom);
+  const middleAvg = avgRank(board.middle);
+  const topAvg = avgRank(board.top);
+
+  // Reward proper ordering (bottom > middle > top by average rank)
+  if (bottomAvg > middleAvg) score += 20;
+  if (middleAvg > topAvg) score += 20;
+
+  // Penalize inversions
+  if (board.bottom.length > 0 && board.middle.length > 0 && bottomAvg < middleAvg) {
+    score -= 50;
+  }
+  if (board.middle.length > 0 && board.top.length > 0 && middleAvg < topAvg) {
+    score -= 50;
+  }
+
+  // Made-hand tier ordering (the strong foul guard during building)
+  const bTier = madeTier(board.bottom);
+  const mTier = madeTier(board.middle);
+  const tTier = madeTier(board.top);
+  if (mTier > bTier) score -= 600 * (mTier - bTier);
+  if (tTier > mTier) score -= 600 * (tTier - mTier);
+
+  // Reward pairs/trips, weighted by row so made hands gravitate DOWNWARD.
+  const ROW_MADE_WEIGHT: Record<Row, number> = { bottom: 1.6, middle: 0.7, top: 0.15 };
+  for (const row of ROWS) {
+    const cards = board[row];
+    const rankMap = new Map<number, number>();
+    for (const c of cards) {
+      rankMap.set(c.rank, (rankMap.get(c.rank) ?? 0) + 1);
+    }
+    for (const count of rankMap.values()) {
+      if (count >= 2) score += 15 * (count - 1) * ROW_MADE_WEIGHT[row];
+    }
+  }
+
+  // Reward flush draws in 5-card rows
+  for (const row of ['bottom', 'middle'] as Row[]) {
+    const cards = board[row];
+    if (cards.length >= 3) {
+      const suitMap = new Map<string, number>();
+      for (const c of cards) {
+        suitMap.set(c.suit, (suitMap.get(c.suit) ?? 0) + 1);
+      }
+      const maxSuit = Math.max(...suitMap.values());
+      if (maxSuit >= 4) score += 25;
+      else if (maxSuit >= 3) score += 10;
+    }
+  }
+
+  // Reward high cards on bottom, low on top
+  score += board.bottom.reduce((s, c) => s + c.rank, 0) * 0.5;
+  score -= board.top.reduce((s, c) => s + c.rank, 0) * 0.3;
+
+  return score;
+}
+
+/** Clone a board. */
+function cloneBoard(board: Board): Board {
+  return {
+    top: [...board.top],
+    middle: [...board.middle],
+    bottom: [...board.bottom],
+  };
+}
+
+/**
+ * Bot strategy for initial deal (5 cards, place all 5).
+ *
+ * Builds a few candidate distributions (pair on bottom, pair on middle,
+ * rank-sorted default) and picks the one whose resulting board scores best,
+ * plus `jitter` noise per candidate.
+ */
+export function botPlaceInitialDeal(hand: Card[], board: Board, jitter = 0): BotDecision {
+  const sorted = [...hand].sort((a, b) => b.rank - a.rank);
+
+  // Try to detect pairs and keep them together
+  const pairs: Card[][] = [];
+  const singles: Card[] = [];
+  const used = new Set<number>();
+
+  for (let i = 0; i < sorted.length; i++) {
+    if (used.has(i)) continue;
+    let foundPair = false;
+    for (let j = i + 1; j < sorted.length; j++) {
+      if (used.has(j)) continue;
+      if (sorted[i].rank === sorted[j].rank) {
+        pairs.push([sorted[i], sorted[j]]);
+        used.add(i);
+        used.add(j);
+        foundPair = true;
+        break;
+      }
+    }
+    if (!foundPair) {
+      singles.push(sorted[i]);
+      used.add(i);
+    }
+  }
+
+  // Build candidate placements and pick the best
+  const candidates: BotDecision[] = [];
+
+  if (pairs.length >= 1) {
+    // Try placing pair on bottom
+    const remaining = pairs.length >= 2
+      ? [...pairs[1], ...singles]
+      : singles;
+    const remainingSorted = remaining.sort((a, b) => b.rank - a.rank);
+
+    const placements: BotPlacement[] = [
+      { card: pairs[0][0], row: 'bottom' },
+      { card: pairs[0][1], row: 'bottom' },
+    ];
+
+    // Fill middle (2 cards) and top (1 card) from remaining
+    if (remainingSorted.length >= 3) {
+      placements.push({ card: remainingSorted[0], row: 'middle' });
+      placements.push({ card: remainingSorted[1], row: 'middle' });
+      placements.push({ card: remainingSorted[2], row: 'top' });
+    }
+    if (placements.length === 5) {
+      candidates.push({ placements });
+    }
+
+    // Also try pair on middle
+    if (pairs.length >= 1) {
+      const alt: BotPlacement[] = [];
+      const altRemaining = [...singles, ...(pairs.length >= 2 ? pairs[1] : [])];
+      const altSorted = altRemaining.sort((a, b) => b.rank - a.rank);
+
+      alt.push({ card: pairs[0][0], row: 'middle' });
+      alt.push({ card: pairs[0][1], row: 'middle' });
+      if (altSorted.length >= 3) {
+        alt.push({ card: altSorted[0], row: 'bottom' });
+        alt.push({ card: altSorted[1], row: 'bottom' });
+        alt.push({ card: altSorted[2], row: 'top' });
+      }
+      if (alt.length === 5) {
+        candidates.push({ placements: alt });
+      }
+    }
+  }
+
+  // Default: simple rank-based distribution
+  const defaultPlacements: BotPlacement[] = [
+    { card: sorted[0], row: 'bottom' },
+    { card: sorted[1], row: 'bottom' },
+    { card: sorted[2], row: 'middle' },
+    { card: sorted[3], row: 'middle' },
+    { card: sorted[4], row: 'top' },
+  ];
+  candidates.push({ placements: defaultPlacements });
+
+  // Score all candidates and pick the best
+  let bestScore = -Infinity;
+  let bestDecision = candidates[0];
+
+  for (const candidate of candidates) {
+    const testBoard = cloneBoard(board);
+    for (const p of candidate.placements) {
+      testBoard[p.row] = [...testBoard[p.row], p.card];
+    }
+    const s = scoreBoard(testBoard) + noise(jitter);
+    if (s > bestScore) {
+      bestScore = s;
+      bestDecision = candidate;
+    }
+  }
+
+  return bestDecision;
+}
+
+/**
+ * Bot strategy for streets 2-5 (3 cards, place 2, discard 1).
+ *
+ * Brute-forces all valid (discard, row assignment) combinations
+ * and picks the placement that scores highest (plus `jitter` noise).
+ */
+export function botPlaceStreet(hand: Card[], board: Board, jitter = 0): BotDecision {
+  let bestScore = -Infinity;
+  let bestDecision: BotDecision | null = null;
+
+  // Try each card as the discard
+  for (let discardIdx = 0; discardIdx < hand.length; discardIdx++) {
+    const discard = hand[discardIdx];
+    const toPlace = hand.filter((_, i) => i !== discardIdx);
+
+    // Try all row assignments for the 2 cards to place
+    for (const rowA of ROWS) {
+      if (rowSpace(board, rowA) < 1) continue;
+
+      for (const rowB of ROWS) {
+        // Check capacity: if same row, need 2 spaces
+        if (rowA === rowB) {
+          if (rowSpace(board, rowA) < 2) continue;
+        } else {
+          if (rowSpace(board, rowB) < 1) continue;
+        }
+
+        const testBoard = cloneBoard(board);
+        testBoard[rowA] = [...testBoard[rowA], toPlace[0]];
+        testBoard[rowB] = [...testBoard[rowB], toPlace[1]];
+
+        const s = scoreBoard(testBoard);
+
+        // Bonus for placing cards where they pair with existing cards
+        const pairBonusA = pairCount(toPlace[0], board[rowA]) * 20;
+        const pairBonusB = pairCount(toPlace[1], board[rowB]) * 20;
+
+        // Bonus for flush draws
+        const suitBonusA = (rowA !== 'top' && suitCount(toPlace[0], board[rowA]) >= 2) ? 10 : 0;
+        const suitBonusB = (rowB !== 'top' && suitCount(toPlace[1], board[rowB]) >= 2) ? 10 : 0;
+
+        const totalScore = s + pairBonusA + pairBonusB + suitBonusA + suitBonusB + noise(jitter);
+
+        if (totalScore > bestScore) {
+          bestScore = totalScore;
+          bestDecision = {
+            placements: [
+              { card: toPlace[0], row: rowA },
+              { card: toPlace[1], row: rowB },
+            ],
+            discard,
+          };
+        }
+      }
+    }
+  }
+
+  // Fallback: should never happen if board has space, but just in case
+  if (!bestDecision) {
+    const sorted = [...hand].sort((a, b) => b.rank - a.rank);
+    const fallbackRows = ROWS.filter((r) => rowSpace(board, r) >= 1);
+    return {
+      placements: [
+        { card: sorted[0], row: fallbackRows[0] || 'bottom' },
+        { card: sorted[1], row: fallbackRows[1] || fallbackRows[0] || 'middle' },
+      ],
+      discard: sorted[2],
+    };
+  }
+
+  return bestDecision;
+}

--- a/frontend/src/saloon/vendor/constants.ts
+++ b/frontend/src/saloon/vendor/constants.ts
@@ -1,0 +1,125 @@
+/**
+ * VENDORED from shared/core/constants.ts for the single-player Saloon mode.
+ * Self-contained — do not import from @shared here.
+ */
+import { HandRank, Rank, ThreeCardHandRank } from './types.ts';
+
+// ---- Royalty tables ----
+
+/** Bottom row (5-card) royalties, keyed by HandRank. */
+export const BOTTOM_ROYALTIES: Record<number, number> = {
+  [HandRank.Straight]: 2,
+  [HandRank.Flush]: 4,
+  [HandRank.FullHouse]: 6,
+  [HandRank.FourOfAKind]: 10,
+  [HandRank.StraightFlush]: 15,
+  [HandRank.RoyalFlush]: 25,
+};
+
+/** Middle row (5-card, doubled) royalties, keyed by HandRank. */
+export const MIDDLE_ROYALTIES: Record<number, number> = {
+  [HandRank.ThreeOfAKind]: 2,
+  [HandRank.Straight]: 4,
+  [HandRank.Flush]: 8,
+  [HandRank.FullHouse]: 12,
+  [HandRank.FourOfAKind]: 20,
+  [HandRank.StraightFlush]: 30,
+  [HandRank.RoyalFlush]: 50,
+};
+
+/** Top row pair royalties, keyed by Rank (6s through Aces). */
+export const TOP_PAIR_ROYALTIES: Record<number, number> = {
+  [Rank.Six]: 1,
+  [Rank.Seven]: 2,
+  [Rank.Eight]: 3,
+  [Rank.Nine]: 4,
+  [Rank.Ten]: 5,
+  [Rank.Jack]: 6,
+  [Rank.Queen]: 7,
+  [Rank.King]: 8,
+  [Rank.Ace]: 9,
+};
+
+/** Top row trips royalties, keyed by Rank (2s through Aces). */
+export const TOP_TRIPS_ROYALTIES: Record<number, number> = {
+  [Rank.Two]: 10,
+  [Rank.Three]: 11,
+  [Rank.Four]: 12,
+  [Rank.Five]: 13,
+  [Rank.Six]: 14,
+  [Rank.Seven]: 15,
+  [Rank.Eight]: 16,
+  [Rank.Nine]: 17,
+  [Rank.Ten]: 18,
+  [Rank.Jack]: 19,
+  [Rank.Queen]: 20,
+  [Rank.King]: 21,
+  [Rank.Ace]: 22,
+};
+
+/** Points deducted per opponent when fouled. */
+export const FOUL_PENALTY = 6;
+
+/** Bonus for winning all 3 rows against an opponent. */
+export const SCOOP_BONUS = 3;
+
+/** Number of cards dealt on the initial street. */
+export const INITIAL_DEAL_COUNT = 5;
+
+/** Number of cards dealt on streets 2-5. */
+export const STREET_DEAL_COUNT = 3;
+
+/** Number of cards to place on streets 2-5 (discard 1). */
+export const STREET_PLACE_COUNT = 2;
+
+/** Total streets in a hand. */
+export const TOTAL_STREETS = 5;
+
+/** Top row size. */
+export const TOP_ROW_SIZE = 3;
+
+/** Middle and bottom row size. */
+export const FIVE_CARD_ROW_SIZE = 5;
+
+/**
+ * Traditional table OFC limit: one shared 52-card deck supports at most
+ * 3 players (3 × 17 cards dealt = 51).
+ */
+export const MAX_TABLE_PLAYERS = 3;
+
+/** Human-readable rank names for display. */
+export const RANK_NAMES: Record<number, string> = {
+  [Rank.Two]: '2',
+  [Rank.Three]: '3',
+  [Rank.Four]: '4',
+  [Rank.Five]: '5',
+  [Rank.Six]: '6',
+  [Rank.Seven]: '7',
+  [Rank.Eight]: '8',
+  [Rank.Nine]: '9',
+  [Rank.Ten]: '10',
+  [Rank.Jack]: 'J',
+  [Rank.Queen]: 'Q',
+  [Rank.King]: 'K',
+  [Rank.Ace]: 'A',
+};
+
+/** Hand rank display names (5-card). */
+export const HAND_RANK_NAMES: Record<number, string> = {
+  [HandRank.HighCard]: 'High Card',
+  [HandRank.Pair]: 'Pair',
+  [HandRank.TwoPair]: 'Two Pair',
+  [HandRank.ThreeOfAKind]: 'Three of a Kind',
+  [HandRank.Straight]: 'Straight',
+  [HandRank.Flush]: 'Flush',
+  [HandRank.FullHouse]: 'Full House',
+  [HandRank.FourOfAKind]: 'Four of a Kind',
+  [HandRank.StraightFlush]: 'Straight Flush',
+  [HandRank.RoyalFlush]: 'Royal Flush',
+};
+
+export const THREE_CARD_HAND_RANK_NAMES: Record<number, string> = {
+  [ThreeCardHandRank.HighCard]: 'High Card',
+  [ThreeCardHandRank.Pair]: 'Pair',
+  [ThreeCardHandRank.ThreeOfAKind]: 'Three of a Kind',
+};

--- a/frontend/src/saloon/vendor/deck.ts
+++ b/frontend/src/saloon/vendor/deck.ts
@@ -1,0 +1,54 @@
+/**
+ * VENDORED from shared/game-logic/deck.ts for the single-player Saloon mode.
+ * Self-contained — do not import from @shared here.
+ */
+import { Rank, Suit } from './types.ts';
+import type { Card } from './types.ts';
+
+const SUITS: readonly string[] = [Suit.Clubs, Suit.Diamonds, Suit.Hearts, Suit.Spades];
+const RANKS: readonly number[] = [
+  Rank.Two, Rank.Three, Rank.Four, Rank.Five, Rank.Six, Rank.Seven,
+  Rank.Eight, Rank.Nine, Rank.Ten, Rank.Jack, Rank.Queen, Rank.King, Rank.Ace,
+];
+
+/** Create a standard 52-card deck (unshuffled). */
+export function createDeck(): Card[] {
+  const deck: Card[] = [];
+  for (const suit of SUITS) {
+    for (const rank of RANKS) {
+      deck.push({ suit: suit as Card['suit'], rank: rank as Card['rank'] });
+    }
+  }
+  return deck;
+}
+
+/** Shuffle an array in place using Fisher-Yates. Returns the same array. */
+export function shuffleDeck(deck: Card[]): Card[] {
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+  return deck;
+}
+
+/**
+ * Deal `count` cards from the top of the deck.
+ * Returns { dealt, remaining } without mutating the input.
+ */
+export function dealCards(
+  deck: Card[],
+  count: number,
+): { dealt: Card[]; remaining: Card[] } {
+  if (count > deck.length) {
+    throw new Error(`Cannot deal ${count} cards from deck of ${deck.length}`);
+  }
+  return {
+    dealt: deck.slice(0, count),
+    remaining: deck.slice(count),
+  };
+}
+
+/** Create a fresh shuffled deck. */
+export function createShuffledDeck(): Card[] {
+  return shuffleDeck(createDeck());
+}

--- a/frontend/src/saloon/vendor/hand-evaluation.ts
+++ b/frontend/src/saloon/vendor/hand-evaluation.ts
@@ -1,0 +1,261 @@
+/**
+ * VENDORED from shared/game-logic/hand-evaluation.ts for the single-player
+ * Saloon mode. Self-contained — do not import from @shared here.
+ */
+import {
+  type Card,
+  type HandEvaluation,
+  HandRank,
+  Rank,
+  type ThreeCardHandEvaluation,
+  ThreeCardHandRank,
+} from './types.ts';
+
+// ---- Helpers ----
+
+/** Sort ranks descending. */
+function sortedRanks(cards: Card[]): number[] {
+  return cards.map((c) => c.rank as number).sort((a, b) => b - a);
+}
+
+/** Count occurrences of each rank. Returns map of rank -> count. */
+function rankCounts(cards: Card[]): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (const c of cards) {
+    counts.set(c.rank, (counts.get(c.rank) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/** Check if all cards share the same suit. */
+function isFlush(cards: Card[]): boolean {
+  return cards.every((c) => c.suit === cards[0].suit);
+}
+
+/**
+ * Check if the sorted ranks form a straight. Returns the high card rank
+ * of the straight, or 0 if not a straight.
+ *
+ * Handles the special case of A-2-3-4-5 (wheel) where ace plays low.
+ */
+function straightHighCard(ranks: number[]): number {
+  // ranks are sorted descending
+  let isStraight = true;
+  for (let i = 1; i < ranks.length; i++) {
+    if (ranks[i - 1] - ranks[i] !== 1) {
+      isStraight = false;
+      break;
+    }
+  }
+  if (isStraight) return ranks[0];
+
+  // Check for wheel: A-5-4-3-2 (sorted: 14,5,4,3,2)
+  if (
+    ranks.length === 5 &&
+    ranks[0] === Rank.Ace &&
+    ranks[1] === Rank.Five &&
+    ranks[2] === Rank.Four &&
+    ranks[3] === Rank.Three &&
+    ranks[4] === Rank.Two
+  ) {
+    return Rank.Five; // 5-high straight
+  }
+
+  return 0;
+}
+
+// ---- 5-card hand evaluation ----
+
+/**
+ * Evaluate a 5-card poker hand. Cards must be exactly 5.
+ *
+ * Returns { handRank, kickers } where kickers encode the hand strength
+ * for tiebreaking within the same handRank.
+ */
+export function evaluate5CardHand(cards: Card[]): HandEvaluation {
+  if (cards.length !== 5) {
+    throw new Error(`Expected 5 cards, got ${cards.length}`);
+  }
+
+  const ranks = sortedRanks(cards);
+  const counts = rankCounts(cards);
+  const flush = isFlush(cards);
+  const strHigh = straightHighCard(ranks);
+  const straight = strHigh > 0;
+
+  // Group ranks by count for classification
+  const groups = Array.from(counts.entries()).sort((a, b) => {
+    // Sort by count descending, then by rank descending
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return b[0] - a[0];
+  });
+
+  // Royal Flush: A-K-Q-J-10 all same suit
+  if (flush && straight && strHigh === Rank.Ace && ranks[4] === Rank.Ten) {
+    return { handRank: HandRank.RoyalFlush, kickers: [Rank.Ace] };
+  }
+
+  // Straight Flush
+  if (flush && straight) {
+    return { handRank: HandRank.StraightFlush, kickers: [strHigh] };
+  }
+
+  // Four of a Kind
+  if (groups[0][1] === 4) {
+    const quadRank = groups[0][0];
+    const kicker = groups[1][0];
+    return { handRank: HandRank.FourOfAKind, kickers: [quadRank, kicker] };
+  }
+
+  // Full House: three of a kind + pair
+  if (groups[0][1] === 3 && groups[1][1] === 2) {
+    return {
+      handRank: HandRank.FullHouse,
+      kickers: [groups[0][0], groups[1][0]],
+    };
+  }
+
+  // Flush
+  if (flush) {
+    return { handRank: HandRank.Flush, kickers: ranks };
+  }
+
+  // Straight
+  if (straight) {
+    return { handRank: HandRank.Straight, kickers: [strHigh] };
+  }
+
+  // Three of a Kind
+  if (groups[0][1] === 3) {
+    const tripRank = groups[0][0];
+    const kickers = groups
+      .slice(1)
+      .map((g) => g[0])
+      .sort((a, b) => b - a);
+    return {
+      handRank: HandRank.ThreeOfAKind,
+      kickers: [tripRank, ...kickers],
+    };
+  }
+
+  // Two Pair
+  if (groups[0][1] === 2 && groups[1][1] === 2) {
+    const highPair = Math.max(groups[0][0], groups[1][0]);
+    const lowPair = Math.min(groups[0][0], groups[1][0]);
+    const kicker = groups[2][0];
+    return {
+      handRank: HandRank.TwoPair,
+      kickers: [highPair, lowPair, kicker],
+    };
+  }
+
+  // One Pair
+  if (groups[0][1] === 2) {
+    const pairRank = groups[0][0];
+    const kickers = groups
+      .slice(1)
+      .map((g) => g[0])
+      .sort((a, b) => b - a);
+    return { handRank: HandRank.Pair, kickers: [pairRank, ...kickers] };
+  }
+
+  // High Card
+  return { handRank: HandRank.HighCard, kickers: ranks };
+}
+
+// ---- 3-card hand evaluation (top row) ----
+
+/**
+ * Evaluate a 3-card hand for the top row.
+ * Only High Card, Pair, and Three of a Kind are possible with 3 cards.
+ */
+export function evaluate3CardHand(cards: Card[]): ThreeCardHandEvaluation {
+  if (cards.length !== 3) {
+    throw new Error(`Expected 3 cards, got ${cards.length}`);
+  }
+
+  const ranks = sortedRanks(cards);
+  const counts = rankCounts(cards);
+
+  const groups = Array.from(counts.entries()).sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return b[0] - a[0];
+  });
+
+  // Three of a Kind
+  if (groups[0][1] === 3) {
+    return {
+      handRank: ThreeCardHandRank.ThreeOfAKind,
+      kickers: [groups[0][0]],
+    };
+  }
+
+  // Pair
+  if (groups[0][1] === 2) {
+    const pairRank = groups[0][0];
+    const kicker = groups[1][0];
+    return {
+      handRank: ThreeCardHandRank.Pair,
+      kickers: [pairRank, kicker],
+    };
+  }
+
+  // High Card
+  return { handRank: ThreeCardHandRank.HighCard, kickers: ranks };
+}
+
+// ---- Comparison ----
+
+/**
+ * Compare two hands of the same type (both 5-card or both 3-card).
+ * Returns:
+ *   1  if hand A wins
+ *   -1 if hand B wins
+ *   0  if tied
+ */
+export function compareHands(
+  a: { handRank: number; kickers: number[] },
+  b: { handRank: number; kickers: number[] },
+): -1 | 0 | 1 {
+  // Higher hand rank wins
+  if (a.handRank > b.handRank) return 1;
+  if (a.handRank < b.handRank) return -1;
+
+  // Same hand rank: compare kickers
+  const len = Math.min(a.kickers.length, b.kickers.length);
+  for (let i = 0; i < len; i++) {
+    if (a.kickers[i] > b.kickers[i]) return 1;
+    if (a.kickers[i] < b.kickers[i]) return -1;
+  }
+
+  return 0;
+}
+
+/**
+ * Compare two 5-card hands directly from cards.
+ * Returns 1 if A wins, -1 if B wins, 0 if tie.
+ */
+export function compare5CardHands(a: Card[], b: Card[]): -1 | 0 | 1 {
+  return compareHands(evaluate5CardHand(a), evaluate5CardHand(b));
+}
+
+/**
+ * Compare two 3-card hands directly from cards.
+ * Returns 1 if A wins, -1 if B wins, 0 if tie.
+ */
+export function compare3CardHands(a: Card[], b: Card[]): -1 | 0 | 1 {
+  return compareHands(evaluate3CardHand(a), evaluate3CardHand(b));
+}
+
+/**
+ * Compare two rows from a board. Uses 3-card eval for top row, 5-card for others.
+ * Returns 1 if A wins, -1 if B wins, 0 if tie.
+ */
+export function compareRows(
+  a: Card[],
+  b: Card[],
+  isTopRow: boolean,
+): -1 | 0 | 1 {
+  if (isTopRow) return compare3CardHands(a, b);
+  return compare5CardHands(a, b);
+}

--- a/frontend/src/saloon/vendor/scoring.ts
+++ b/frontend/src/saloon/vendor/scoring.ts
@@ -1,0 +1,262 @@
+/**
+ * VENDORED from shared/game-logic/scoring.ts for the single-player Saloon
+ * mode. Self-contained — do not import from @shared here.
+ */
+import {
+  BOTTOM_ROYALTIES,
+  FOUL_PENALTY,
+  MIDDLE_ROYALTIES,
+  SCOOP_BONUS,
+  TOP_PAIR_ROYALTIES,
+  TOP_TRIPS_ROYALTIES,
+} from './constants.ts';
+import {
+  compare5CardHands,
+  compareRows,
+  evaluate3CardHand,
+  evaluate5CardHand,
+} from './hand-evaluation.ts';
+import {
+  type Board,
+  HandRank,
+  type PairwiseResult,
+  type PlayerScore,
+  type ScoringResult,
+  ThreeCardHandRank,
+} from './types.ts';
+
+// ---- Foul detection ----
+
+/**
+ * A board is fouled if the rows are not in ascending order:
+ * bottom >= middle > top
+ *
+ * A board with incomplete rows is not considered fouled (game in progress).
+ */
+export function isFoul(board: Board): boolean {
+  // Incomplete board - not fouled (game in progress)
+  if (board.top.length < 3 || board.middle.length < 5 || board.bottom.length < 5) {
+    return false;
+  }
+
+  // Check bottom >= middle (both 5-card)
+  const bottomVsMiddle = compare5CardHands(board.bottom, board.middle);
+  if (bottomVsMiddle < 0) return true; // bottom is weaker than middle
+
+  // Check middle > top
+  const middleEval = evaluate5CardHand(board.middle);
+  const topEval = evaluate3CardHand(board.top);
+
+  // Map ThreeCardHandRank to HandRank for comparison
+  const topMappedRank = mapThreeCardToFiveCardRank(topEval.handRank);
+
+  // Middle must be strictly greater than top
+  if (middleEval.handRank > topMappedRank) return false;
+  if (middleEval.handRank < topMappedRank) return true;
+
+  // Same hand rank category: compare kickers
+  const len = Math.min(middleEval.kickers.length, topEval.kickers.length);
+  for (let i = 0; i < len; i++) {
+    if (middleEval.kickers[i] > topEval.kickers[i]) return false;
+    if (middleEval.kickers[i] < topEval.kickers[i]) return true;
+  }
+
+  return true; // middle == top is a foul (must be strictly greater)
+}
+
+/** Map a 3-card hand rank to the equivalent 5-card hand rank for comparison. */
+function mapThreeCardToFiveCardRank(rank: ThreeCardHandRank): HandRank {
+  switch (rank) {
+    case ThreeCardHandRank.HighCard:
+      return HandRank.HighCard;
+    case ThreeCardHandRank.Pair:
+      return HandRank.Pair;
+    case ThreeCardHandRank.ThreeOfAKind:
+      return HandRank.ThreeOfAKind;
+  }
+}
+
+// ---- Royalty calculation ----
+
+/**
+ * Calculate royalties for a complete board.
+ * Returns per-row and total royalties. Incomplete rows earn 0.
+ */
+export function calculateRoyalties(board: Board): { top: number; middle: number; bottom: number; total: number } {
+  let top = 0;
+  let middle = 0;
+  let bottom = 0;
+
+  // Top row (3-card): pairs 6+ and trips
+  if (board.top.length === 3) {
+    const eval3 = evaluate3CardHand(board.top);
+    if (eval3.handRank === ThreeCardHandRank.ThreeOfAKind) {
+      top = TOP_TRIPS_ROYALTIES[eval3.kickers[0]] ?? 0;
+    } else if (eval3.handRank === ThreeCardHandRank.Pair) {
+      top = TOP_PAIR_ROYALTIES[eval3.kickers[0]] ?? 0;
+    }
+  }
+
+  // Middle row (5-card, doubled values)
+  if (board.middle.length === 5) {
+    const eval5 = evaluate5CardHand(board.middle);
+    middle = MIDDLE_ROYALTIES[eval5.handRank] ?? 0;
+  }
+
+  // Bottom row (5-card)
+  if (board.bottom.length === 5) {
+    const eval5 = evaluate5CardHand(board.bottom);
+    bottom = BOTTOM_ROYALTIES[eval5.handRank] ?? 0;
+  }
+
+  return { top, middle, bottom, total: top + middle + bottom };
+}
+
+// ---- Pairwise scoring ----
+
+/**
+ * Score player A vs player B.
+ * Returns PairwiseResult from A's perspective.
+ *
+ * Rules:
+ * - If both fouled: 0 points each
+ * - If one fouled: non-fouled player gets +FOUL_PENALTY, fouled player gets -FOUL_PENALTY
+ * - Otherwise: +1/-1 per row won/lost, +3 scoop for sweeping all 3
+ */
+export function scorePairwise(
+  playerAUid: string,
+  playerAFouled: boolean,
+  playerABoard: Board,
+  playerBUid: string,
+  playerBFouled: boolean,
+  playerBBoard: Board,
+): PairwiseResult {
+  // Both fouled: 0 all around
+  if (playerAFouled && playerBFouled) {
+    return {
+      playerA: playerAUid,
+      playerB: playerBUid,
+      rowPoints: 0,
+      scoopBonus: 0,
+      royalties: 0,
+      total: 0,
+    };
+  }
+
+  // A fouled: B gets penalty, no royalties
+  if (playerAFouled) {
+    return {
+      playerA: playerAUid,
+      playerB: playerBUid,
+      rowPoints: -FOUL_PENALTY,
+      scoopBonus: 0,
+      royalties: 0,
+      total: -FOUL_PENALTY,
+    };
+  }
+
+  // B fouled: A gets penalty, no royalties
+  if (playerBFouled) {
+    return {
+      playerA: playerAUid,
+      playerB: playerBUid,
+      rowPoints: FOUL_PENALTY,
+      scoopBonus: 0,
+      royalties: 0,
+      total: FOUL_PENALTY,
+    };
+  }
+
+  // Neither fouled: compare row by row
+  const topResult = compareRows(playerABoard.top, playerBBoard.top, true);
+  const middleResult = compareRows(
+    playerABoard.middle,
+    playerBBoard.middle,
+    false,
+  );
+  const bottomResult = compareRows(
+    playerABoard.bottom,
+    playerBBoard.bottom,
+    false,
+  );
+
+  const rowPoints = topResult + middleResult + bottomResult;
+
+  // Scoop: all 3 rows won
+  let scoopBonus = 0;
+  if (topResult === 1 && middleResult === 1 && bottomResult === 1) {
+    scoopBonus = SCOOP_BONUS;
+  } else if (topResult === -1 && middleResult === -1 && bottomResult === -1) {
+    scoopBonus = -SCOOP_BONUS;
+  }
+
+  // Royalties: net differential (A's total - B's total)
+  const aRoyalties = calculateRoyalties(playerABoard).total;
+  const bRoyalties = calculateRoyalties(playerBBoard).total;
+  const royalties = aRoyalties - bRoyalties;
+
+  return {
+    playerA: playerAUid,
+    playerB: playerBUid,
+    rowPoints,
+    scoopBonus,
+    royalties,
+    total: rowPoints + scoopBonus + royalties,
+  };
+}
+
+// ---- Multi-player scoring ----
+
+/**
+ * Score all players pairwise. Takes boards map and fouls map.
+ * Fouls map includes both auto-fouls (timeout) and natural fouls (bad row ordering).
+ */
+export function scoreAllPlayers(
+  boards: Map<string, Board>,
+  fouls: Map<string, boolean>,
+): ScoringResult {
+  const uids = Array.from(boards.keys());
+  const scores = new Map<string, PlayerScore>();
+
+  // Initialize
+  for (const uid of uids) {
+    scores.set(uid, {
+      uid,
+      fouled: fouls.get(uid) ?? false,
+      netScore: 0,
+      pairwise: [],
+    });
+  }
+
+  // Score each pair
+  for (let i = 0; i < uids.length; i++) {
+    for (let j = i + 1; j < uids.length; j++) {
+      const uidA = uids[i];
+      const uidB = uids[j];
+      const boardA = boards.get(uidA)!;
+      const boardB = boards.get(uidB)!;
+      const aFouled = fouls.get(uidA) ?? false;
+      const bFouled = fouls.get(uidB) ?? false;
+
+      const result = scorePairwise(uidA, aFouled, boardA, uidB, bFouled, boardB);
+
+      // Store A's perspective
+      scores.get(uidA)!.pairwise.push(result);
+      scores.get(uidA)!.netScore += result.total;
+
+      // Store B's perspective (inverted)
+      const invertedResult: PairwiseResult = {
+        playerA: uidB,
+        playerB: uidA,
+        rowPoints: -result.rowPoints,
+        scoopBonus: -result.scoopBonus,
+        royalties: -result.royalties,
+        total: -result.total,
+      };
+      scores.get(uidB)!.pairwise.push(invertedResult);
+      scores.get(uidB)!.netScore += invertedResult.total;
+    }
+  }
+
+  return { players: uids.map((uid) => scores.get(uid)!) };
+}

--- a/frontend/src/saloon/vendor/types.ts
+++ b/frontend/src/saloon/vendor/types.ts
@@ -1,0 +1,106 @@
+/**
+ * VENDORED from shared/core/types.ts for the single-player Saloon mode.
+ *
+ * The Saloon (Frontier Trail) mode is deliberately decoupled from the
+ * multiplayer stack — it runs entirely client-side with no Firebase. Keep
+ * this copy self-contained; do not import from @shared here.
+ */
+
+export const Suit = {
+  Clubs: 'c',
+  Diamonds: 'd',
+  Hearts: 'h',
+  Spades: 's',
+} as const;
+export type Suit = (typeof Suit)[keyof typeof Suit];
+
+export const Rank = {
+  Two: 2,
+  Three: 3,
+  Four: 4,
+  Five: 5,
+  Six: 6,
+  Seven: 7,
+  Eight: 8,
+  Nine: 9,
+  Ten: 10,
+  Jack: 11,
+  Queen: 12,
+  King: 13,
+  Ace: 14,
+} as const;
+export type Rank = (typeof Rank)[keyof typeof Rank];
+
+export const HandRank = {
+  HighCard: 0,
+  Pair: 1,
+  TwoPair: 2,
+  ThreeOfAKind: 3,
+  Straight: 4,
+  Flush: 5,
+  FullHouse: 6,
+  FourOfAKind: 7,
+  StraightFlush: 8,
+  RoyalFlush: 9,
+} as const;
+export type HandRank = (typeof HandRank)[keyof typeof HandRank];
+
+/** For 3-card top row, only these ranks are possible. */
+export const ThreeCardHandRank = {
+  HighCard: 0,
+  Pair: 1,
+  ThreeOfAKind: 2,
+} as const;
+export type ThreeCardHandRank =
+  (typeof ThreeCardHandRank)[keyof typeof ThreeCardHandRank];
+
+export const Row = {
+  Top: 'top',
+  Middle: 'middle',
+  Bottom: 'bottom',
+} as const;
+export type Row = (typeof Row)[keyof typeof Row];
+
+export interface Card {
+  suit: Suit;
+  rank: Rank;
+}
+
+export interface Board {
+  top: Card[];    // max 3
+  middle: Card[]; // max 5
+  bottom: Card[]; // max 5
+}
+
+export interface HandEvaluation {
+  handRank: HandRank;
+  /** Kickers sorted for tiebreaking (meaning depends on hand type). */
+  kickers: number[];
+}
+
+export interface ThreeCardHandEvaluation {
+  handRank: ThreeCardHandRank;
+  kickers: number[];
+}
+
+// ---- Scoring types ----
+
+export interface PairwiseResult {
+  playerA: string;
+  playerB: string;
+  rowPoints: number;
+  scoopBonus: number;
+  royalties: number;   // net royalty differential (A's total - B's total)
+  total: number;
+}
+
+export interface PlayerScore {
+  uid: string;
+  fouled: boolean;
+  netScore: number;
+  pairwise: PairwiseResult[];
+}
+
+export interface ScoringResult {
+  players: PlayerScore[];
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['frontend/src/**/*.test.ts'],
+    root: '.',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev:status": "./scripts/check-services.sh",
     "test": "npx playwright test",
     "test:stress": "npx playwright test e2e/stress.spec.ts",
-    "test:unit": "vitest run --config shared/vitest.config.ts && npm run test:unit -w dealer",
+    "test:unit": "vitest run --config shared/vitest.config.ts && vitest run --config frontend/vitest.config.ts && npm run test:unit -w dealer",
     "test:dealer": "npm test -w dealer",
     "test:dealer:unit": "npm run test:unit -w dealer",
     "test:dealer:integration": "npm run test:integration -w dealer"


### PR DESCRIPTION
## What

A fully client-side single-player experience on its own route (`/?saloon=1`, linked from the home screen), completely separate from the multiplayer stack — no Firebase, no rooms, no dealer.

Unlike the multiplayer game (per-player decks, simultaneous placement), this is **traditional table OFC Pineapple**: one shared 52-card deck, turn-based placement clockwise from a rotating button, max 3 seats (3 × 17 = 51 cards).

## Campaign — "The Frontier Trail"

Governor-of-Poker-style old-West ladder of 5 locales with named bot characters:

| Stop | Locale | Opponents | Skill | Stake | Hands |
|---|---|---|---|---|---|
| 1 | Dusty Gulch | Tumbleweed Ted | Greenhorn | $1/pt | 3 |
| 2 | Rattlesnake Creek | Calamity Kate | Gunslinger | $2/pt | 4 |
| 3 | Silver City Saloon | Doc Maybury, Snake-Eye Sam | Gunslinger | $3/pt | 4 |
| 4 | Deadwood Card Hall | Marshal Brodie, Black-Hat Bart | Outlaw | $5/pt | 5 |
| 5 | The Governor's Parlor | The Governor | Outlaw | $10/pt | 6 |

Skill tiers are score jitter on the proven greedy bot strategy — greenhorns genuinely misplay (and occasionally foul); outlaws play it straight. Beat the table (most points) to unlock the next stop; winnings settle into a persistent dollar bankroll (`saloon_progress_v1` in localStorage).

## How

- **Vendored logic**: everything taken from multiplayer is *copied* into `frontend/src/saloon/vendor/` (types, constants, deck, hand-eval, scoring from `shared/`; bot strategy from `dealer/`) so the mode stays decoupled
- **`engine.ts`**: pure turn-based shared-deck state machine (deal → turn → street → showdown → button rotation → match over)
- **UI**: western-themed campaign map, table, boards, and cards; hand/match showdown overlays; same tap-card/tap-row placement UX as multiplayer incl. take-backs and auto-discard

## Testing

- 11 new engine unit tests (turn order, shared-deck uniqueness, scoring zero-sum, match flow, bot-vs-bot full matches at every skill tier) — `frontend/vitest.config.ts` is now wired into root `npm run test:unit`, which previously skipped frontend tests
- New `e2e/saloon.spec.ts`: campaign map gating + two turn-based streets vs a bot
- Build, lint, and all 153 unit tests pass locally

https://claude.ai/code/session_01Dkn5nkVYdV8Cef4qjjeP3V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dkn5nkVYdV8Cef4qjjeP3V)_